### PR TITLE
Removed call to GetDiagnostics as it may cause a deadlock. Used taint…

### DIFF
--- a/SecurityCodeScan.Test/Tests/UnsafeDeserializationAnalyzerTests.cs
+++ b/SecurityCodeScan.Test/Tests/UnsafeDeserializationAnalyzerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using SecurityCodeScan.Analyzers;
 using SecurityCodeScan.Test.Helpers;
@@ -537,10 +538,10 @@ End Namespace
         }
 
         [DataTestMethod]
-        [DataRow("TypeNameHandling.Test", "CS0117", "BC30456")]
-        [DataRow("foo()",                 "CS0029", "BC30311")]
-        [DataRow("foo2(xyz)",             "CS0103", "BC30451")]
-        public async Task IgnoreJSonSerializerTypeNameHandlingNonCompilingValue(string right, string csError, string vbError)
+        [DataRow("TypeNameHandling.Test", new[] { "CS0117" },            new[] { "BC30456" })]
+        [DataRow("foo()",                 new[] { "CS0029" },            new[] { "BC30311" })]
+        [DataRow("foo2(xyz)",             new[] { "SCS0028", "CS0103" }, new[] { "SCS0028", "BC30451" })]
+        public async Task JSonSerializerTypeNameHandlingNonCompilingValue(string right, string[] csErrors, string[] vbErrors)
         {
             var cSharpTest = $@"
 using Newtonsoft.Json;
@@ -593,8 +594,12 @@ Namespace VulnerableApp
 End Namespace
 ";
 
-            await VerifyCSharpDiagnostic(cSharpTest, new DiagnosticResult { Id = csError }.WithLocation("Test0.cs", 12)).ConfigureAwait(false);
-            await VerifyVisualBasicDiagnostic(visualBasicTest, new DiagnosticResult { Id = vbError }.WithLocation("Test0.vb", 9))
+            await VerifyCSharpDiagnostic(cSharpTest,
+                                         csErrors.Select(x => new DiagnosticResult { Id = x }.WithLocation("Test0.cs", 12)).ToArray())
+                .ConfigureAwait(false);
+
+            await VerifyVisualBasicDiagnostic(visualBasicTest,
+                                              vbErrors.Select(x => new DiagnosticResult { Id = x }.WithLocation("Test0.vb", 9)).ToArray())
                 .ConfigureAwait(false);
         }
 

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -384,7 +384,7 @@ namespace SecurityCodeScan.Analyzers.Taint
         {
             var symbol = state.GetSymbol(node);
             if (symbol == null)
-                return new VariableState(node, VariableTaint.Safe); // don't show warnings if doesn't compile
+                return new VariableState(node, VariableTaint.Unknown);
 
             var behavior    = symbol.GetMethodBehavior(state.AnalysisContext.Options.AdditionalFiles);
             var returnState = initialVariableState.HasValue && !symbol.IsStatic
@@ -468,11 +468,11 @@ namespace SecurityCodeScan.Analyzers.Taint
             {
                 var rightTypeSymbol = state.AnalysisContext.SemanticModel.GetTypeInfo(node.Right).Type;
                 if (rightTypeSymbol == null)
-                    return new VariableState(node.Right, VariableTaint.Safe);
+                    return new VariableState(node.Right, VariableTaint.Unknown);
 
-                var leftTypeSymbol  = state.AnalysisContext.SemanticModel.GetTypeInfo(node.Left).Type;
+                var leftTypeSymbol = state.AnalysisContext.SemanticModel.GetTypeInfo(node.Left).Type;
                 if (!state.AnalysisContext.SemanticModel.Compilation.ClassifyConversion(rightTypeSymbol, leftTypeSymbol).IsImplicit)
-                    return new VariableState(node.Right, VariableTaint.Safe);
+                    return new VariableState(node.Right, VariableTaint.Unknown);
             }
 
             IdentifierNameSyntax parentIdentifierSyntax = GetParentIdentifier(node.Left);
@@ -544,7 +544,7 @@ namespace SecurityCodeScan.Analyzers.Taint
             switch (symbol)
             {
                 case null:
-                    return new VariableState(expression, VariableTaint.Safe); // don't show warnings if doesn't compile
+                    return new VariableState(expression, VariableTaint.Unknown);
                 case IFieldSymbol field:
                     if (field.IsConst)
                         return new VariableState(expression, VariableTaint.Constant);

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -384,7 +384,7 @@ namespace SecurityCodeScan.Analyzers.Taint
         {
             var symbol = state.GetSymbol(node);
             if (symbol == null)
-                return new VariableState(node, VariableTaint.Unknown);
+                return new VariableState(node, VariableTaint.Safe); // don't show warnings if doesn't compile
 
             var behavior    = symbol.GetMethodBehavior(state.AnalysisContext.Options.AdditionalFiles);
             var returnState = initialVariableState.HasValue && !symbol.IsStatic
@@ -451,17 +451,28 @@ namespace SecurityCodeScan.Analyzers.Taint
 
         private VariableState VisitAssignment(AssignmentExpressionSyntax node, ExecutionState state)
         {
-            var            symbol   = state.GetSymbol(node.Left);
+            var            leftSymbol   = state.GetSymbol(node.Left);
             MethodBehavior behavior = null;
-            if (symbol != null)
-                behavior = symbol.GetMethodBehavior(state.AnalysisContext.Options.AdditionalFiles);
+            if (leftSymbol != null)
+                behavior = leftSymbol.GetMethodBehavior(state.AnalysisContext.Options.AdditionalFiles);
 
             var variableState = VisitExpression(node.Right, state);
 
             //Additional analysis by extension
             foreach (var ext in Extensions)
             {
-                ext.VisitAssignment(node, state, behavior, symbol, variableState);
+                ext.VisitAssignment(node, state, behavior, leftSymbol, variableState);
+            }
+
+            if (leftSymbol != null)
+            {
+                var rightTypeSymbol = state.AnalysisContext.SemanticModel.GetTypeInfo(node.Right).Type;
+                if (rightTypeSymbol == null)
+                    return new VariableState(node.Right, VariableTaint.Safe);
+
+                var leftTypeSymbol  = state.AnalysisContext.SemanticModel.GetTypeInfo(node.Left).Type;
+                if (!state.AnalysisContext.SemanticModel.Compilation.ClassifyConversion(rightTypeSymbol, leftTypeSymbol).IsImplicit)
+                    return new VariableState(node.Right, VariableTaint.Safe);
             }
 
             IdentifierNameSyntax parentIdentifierSyntax = GetParentIdentifier(node.Left);
@@ -533,7 +544,7 @@ namespace SecurityCodeScan.Analyzers.Taint
             switch (symbol)
             {
                 case null:
-                    return new VariableState(expression, VariableTaint.Unknown);
+                    return new VariableState(expression, VariableTaint.Safe); // don't show warnings if doesn't compile
                 case IFieldSymbol field:
                     if (field.IsConst)
                         return new VariableState(expression, VariableTaint.Constant);

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -317,7 +317,7 @@ namespace SecurityCodeScan.Analyzers.Taint
         {
             var symbol = state.GetSymbol(node);
             if (symbol == null)
-                return new VariableState(node, VariableTaint.Safe); // don't show warnings if doesn't compile
+                return new VariableState(node, VariableTaint.Unknown);
 
             var behavior    = symbol.GetMethodBehavior(state.AnalysisContext.Options.AdditionalFiles);
             var returnState = initialVariableState.HasValue && !symbol.IsStatic
@@ -403,11 +403,11 @@ namespace SecurityCodeScan.Analyzers.Taint
             {
                 var rightTypeSymbol = state.AnalysisContext.SemanticModel.GetTypeInfo(rightExpression).Type;
                 if (rightTypeSymbol == null)
-                    return new VariableState(rightExpression, VariableTaint.Safe);
+                    return new VariableState(rightExpression, VariableTaint.Unknown);
 
                 var leftTypeSymbol = state.AnalysisContext.SemanticModel.GetTypeInfo(leftExpression).Type;
                 if (!state.AnalysisContext.SemanticModel.Compilation.ClassifyConversion(rightTypeSymbol, leftTypeSymbol).Exists)
-                    return new VariableState(rightExpression, VariableTaint.Safe);
+                    return new VariableState(rightExpression, VariableTaint.Unknown);
             }
 
             IdentifierNameSyntax parentIdentifierSyntax = GetParentIdentifier(leftExpression);
@@ -488,7 +488,7 @@ namespace SecurityCodeScan.Analyzers.Taint
             switch (symbol)
             {
                 case null:
-                    return new VariableState(expression, VariableTaint.Safe); // don't show warnings if doesn't compile
+                    return new VariableState(expression, VariableTaint.Unknown);
                 case IFieldSymbol field:
                     if (field.IsConst)
                         return new VariableState(expression, VariableTaint.Constant);

--- a/SecurityCodeScan/Analyzers/UnsafeDeserializationAnalyzer.cs
+++ b/SecurityCodeScan/Analyzers/UnsafeDeserializationAnalyzer.cs
@@ -41,11 +41,6 @@ namespace SecurityCodeScan.Analyzers
 
         protected void VisitAttributeArgument(SyntaxNodeAnalysisContext ctx, SyntaxNodeHelper nodeHelper)
         {
-            //if expression has errors no diagnostics can be returned
-            var diagnostics = ctx.SemanticModel.GetDiagnostics(ctx.Node.Span);
-            if (diagnostics.Any(diag => diag.DefaultSeverity == DiagnosticSeverity.Error))
-                return;
-
             var name = nodeHelper.GetNameNode(ctx.Node);
 
             if (name == null)
@@ -66,11 +61,6 @@ namespace SecurityCodeScan.Analyzers
 
         protected void VisitAssignment(SyntaxNodeAnalysisContext ctx, SyntaxNodeHelper nodeHelper)
         {
-            //if expression has errors no diagnostics can be returned
-            var diagnostics = ctx.SemanticModel.GetDiagnostics(ctx.Node.Span);
-            if (diagnostics.Any(diag => diag.DefaultSeverity == DiagnosticSeverity.Error))
-                return;
-
             var leftNode = nodeHelper.GetAssignmentLeftNode(ctx.Node);
 
             if (!leftNode.ToString().EndsWith("TypeNameHandling"))
@@ -90,11 +80,8 @@ namespace SecurityCodeScan.Analyzers
         {
             var value = ctx.SemanticModel.GetConstantValue(expression);
 
-            if (!value.HasValue && IsDiagnosticsForUnknownValuesEnabled())
-            {
-                ctx.ReportDiagnostic(Diagnostic.Create(Rule, expression.GetLocation()));
+            if (!value.HasValue)
                 return;
-            }
 
             //check if it is really integer, because visual basic allows to assign string values to enums
             if (value.Value is int intValue && intValue != 0 /*TypeNameHandling.None*/ )
@@ -120,12 +107,6 @@ namespace SecurityCodeScan.Analyzers
 
             if (ctx.SemanticModel.GetSymbolInfo(firstArgument).Symbol != null)
                 ctx.ReportDiagnostic(Diagnostic.Create(Rule, ctx.Node.GetLocation()));
-        }
-
-        // TODO: return diagnostics for unknowns only if auditing mode is enabled
-        public bool IsDiagnosticsForUnknownValuesEnabled()
-        {
-            return true;
         }
     }
 }

--- a/SecurityCodeScan/Config/Main.yml
+++ b/SecurityCodeScan/Config/Main.yml
@@ -1297,6 +1297,14 @@ Sinks:
      InjectableArguments: [0]
      Locale: SCS0028
 
+  TypeNameHandling_enum:
+    Namespace: Newtonsoft.Json
+    ClassName: JsonSerializerSettings
+    Member: field
+    Name: TypeNameHandling
+    InjectableField: true
+    Locale: SCS0028
+
 #Password
   PasswordDeriveBytes:
     Namespace: System.Security.Cryptography


### PR DESCRIPTION
… analyzer instead to evaluate non-const values.

I have noticed VS constantly consuming CPU while working with a real solution. Looked like some analysis didn't finish. Attached with debugger and found that SCS is spin-waiting on `GetDiagnostics`. Looks like it was bad idea to call for diagnostics while analyzing even if it is a bug in Roslyn engine.

I have made a somewhat hackish change to the taint analyzer to keep silent when the assignment shouldn't compile. But added some tests, looks working.