### PR TITLE
Expand handling of Expression Bodies

### DIFF
--- a/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
+++ b/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
@@ -473,6 +473,9 @@
     <Reference Include="System.Xml.XPath.XDocument, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
     </Reference>
+    <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.5.2.1\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helpers\CsToVbConverter.cs" />

--- a/SecurityCodeScan.Test/Tests/XssPreventionAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/XssPreventionAnalyzerTest.cs
@@ -53,6 +53,25 @@ namespace SecurityCodeScan.Test
 
         #region Tests that are producing diagnostics
 
+        [TestCategory("Detect")]
+        [TestMethod]
+        public async Task XssFromCSharpExpressionBody()
+        {
+            const string cSharpTest = @"
+using System.Web;
+
+class Vulnerable
+{
+    public static HttpResponse Response = null;
+    public static HttpRequest  Request  = null;
+
+    public static void Run()
+    => Response.Write(Request.Params[0]);
+}
+";
+            await VerifyCSharpDiagnostic(cSharpTest, Expected.WithLocation(10, 23)).ConfigureAwait(false);
+        }
+
         [DataRow("Sink((from x in new SampleContext().TestProp where x == \"aaa\" select x).SingleOrDefault())", true)]
         [DataRow("Sink((from x in new SampleContext().TestField where x == \"aaa\" select x).SingleOrDefault())", true)]
         [DataTestMethod]
@@ -430,7 +449,6 @@ End Class
                 await VerifyVisualBasicDiagnostic(visualBasicTest).ConfigureAwait(false);
             }
         }
-
 
         #endregion
 

--- a/SecurityCodeScan.Test/Tests/XssPreventionAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/XssPreventionAnalyzerTest.cs
@@ -249,6 +249,26 @@ End Namespace
 
         [TestCategory("Detect")]
         [TestMethod]
+        public async Task UnencodedInputDataExpression()
+        {
+            const string cSharpTest = @"
+using Microsoft.AspNetCore.Mvc;
+
+namespace VulnerableApp
+{
+    public class TestController : Controller
+    {
+        [HttpGet(""{inputData}"")]
+        public string Get(int inputData) => ""value "" + inputData;
+    }
+}
+            ";
+
+            await VerifyCSharpDiagnostic(cSharpTest, Expected).ConfigureAwait(false);
+        }
+
+        [TestCategory("Detect")]
+        [TestMethod]
         public async Task UnencodedInputData()
         {
             const string cSharpTest = @"

--- a/SecurityCodeScan.Test/packages.config
+++ b/SecurityCodeScan.Test/packages.config
@@ -165,4 +165,5 @@
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="YamlDotNet" version="5.2.1" targetFramework="net461" />
 </packages>

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -113,10 +113,13 @@ namespace SecurityCodeScan.Analyzers.Taint
                 }
             }
 
-            if (node.Body == null)
-                return new VariableState(node, VariableTaint.Unknown);
+            if(node.ExpressionBody != null)
+                return VisitExpression(node.ExpressionBody.Expression, state);
 
-            return VisitBlock(node.Body, state);
+            if (node.Body != null)
+                return VisitBlock(node.Body, state);
+
+            return new VariableState(node, VariableTaint.Unknown);
         }
 
         private VariableState VisitForEach(ForEachStatementSyntax node, ExecutionState state)

--- a/SecurityCodeScan/Analyzers/XssPreventionAnalyzer.cs
+++ b/SecurityCodeScan/Analyzers/XssPreventionAnalyzer.cs
@@ -50,16 +50,28 @@ namespace SecurityCodeScan.Analyzers
 
             foreach (CSharpSyntax.MethodDeclarationSyntax method in methodsWithParameters)
             {
-                SyntaxList<CSharpSyntax.StatementSyntax> methodStatements = method.Body.Statements;
-                var methodInvocations = method.DescendantNodes()
-                                              .OfType<CSharpSyntax.InvocationExpressionSyntax>()
-                                              .ToArray();
+                DataFlowAnalysis flow;
+                if (method.Body != null)
+                {
+                    SyntaxList<CSharpSyntax.StatementSyntax> methodStatements = method.Body.Statements;
+                    if (!methodStatements.Any())
+                        continue;
 
-                if (!methodStatements.Any())
+                    flow = ctx.SemanticModel.AnalyzeDataFlow(methodStatements.First(),
+                                                             methodStatements.Last());
+                }
+                else if(method.ExpressionBody != null)
+                {
+                    flow = ctx.SemanticModel.AnalyzeDataFlow(method.ExpressionBody.Expression);
+                }
+                else
+                {
                     continue;
+                }
 
-                DataFlowAnalysis flow = ctx.SemanticModel.AnalyzeDataFlow(methodStatements.First(),
-                                                                          methodStatements.Last());
+                var methodInvocations = method.DescendantNodes()
+                                                  .OfType<CSharpSyntax.InvocationExpressionSyntax>()
+                                                  .ToArray();
 
                 // Returns from the Data Flow Analysis of input data 
                 // Dangerous data is: Data passed as a parameter that is also returned as is by the method

--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -12,6 +12,11 @@ namespace SecurityCodeScan.Config
     /// </summary>
     internal class Configuration
     {
+        static Configuration()
+        {
+            System.Diagnostics.Debugger.Launch();
+        }
+
         public Configuration()
         {
             _PasswordValidatorRequiredProperties = new HashSet<string>();

--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -12,11 +12,6 @@ namespace SecurityCodeScan.Config
     /// </summary>
     internal class Configuration
     {
-        static Configuration()
-        {
-            System.Diagnostics.Debugger.Launch();
-        }
-
         public Configuration()
         {
             _PasswordValidatorRequiredProperties = new HashSet<string>();


### PR DESCRIPTION
Pulling out a change from #127 that fixes up a few remaining places that assumed methods only had blocks with statements, instead of the (new) case where they can be implemented as a single expression.

Also fixes up a reference to YamlDotNet in the test project that somehow slipped through the cracks.