### PR TITLE
Fix handling of named parameters

### DIFF
--- a/SecurityCodeScan.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/SecurityCodeScan.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -74,7 +74,7 @@ namespace SecurityCodeScan.Test.Helpers
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
 
         private static readonly CompilationOptions CSharpDefaultOptions      = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-        private static readonly CompilationOptions VisualBasicDefaultOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        private static readonly CompilationOptions VisualBasicDefaultOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, embedVbCoreRuntime: true);
 
         public const string DefaultFilePathPrefix = "Test";
         public const string CSharpDefaultFileExt  = "cs";

--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -136,6 +136,7 @@ Module TestExtensions
     Public Sub Injectable2(ByVal self As Test, ByVal dangerous As String, ByVal safe As String)
     End Sub
 
+    <Extension()>
     Public Sub InjectableOpt2(ByVal self As Test, ByVal Optional dangerous As String = ""foo"", ByVal Optional safe As String = ""bar"")
     End Sub
 End Module
@@ -181,7 +182,7 @@ TaintEntryPoints:
             if (warn)
             {
                 await VerifyCSharpDiagnostic(cSharpTest, Expected.WithLocation(32), testConfig).ConfigureAwait(false);
-                await VerifyVisualBasicDiagnostic(vbTest, Expected.WithLocation(24), testConfig).ConfigureAwait(false);
+                await VerifyVisualBasicDiagnostic(vbTest, Expected.WithLocation(25), testConfig).ConfigureAwait(false);
             }
             else
             {

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -645,7 +645,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                                                                           ? VariableTaint.Unset
                                                                           : VariableTaint.Unknown);
 
-            var reducedMethodSymbol = (methodSymbol.ReducedFrom ?? methodSymbol);
+            var reducedMethodSymbol = (methodSymbol?.ReducedFrom ?? methodSymbol);
             var methodParameterCount = methodSymbol != null ? reducedMethodSymbol.Parameters.Length : 0;
             var argCount       = argList?.Arguments.Count;
             var argumentStates = argCount.HasValue &&

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -645,12 +645,14 @@ namespace SecurityCodeScan.Analyzers.Taint
                                                                           ? VariableTaint.Unset
                                                                           : VariableTaint.Unknown);
 
+            var reducedMethodSymbol = (methodSymbol.ReducedFrom ?? methodSymbol);
+            var methodParameterCount = methodSymbol != null ? reducedMethodSymbol.Parameters.Length : 0;
             var argCount       = argList?.Arguments.Count;
             var argumentStates = argCount.HasValue &&
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
-                                  methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[(methodSymbol.ReducedFrom ?? methodSymbol).Parameters.Length]
+                                  methodSymbol != null && reducedMethodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
+                                     ? new VariableState[methodParameterCount]
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
@@ -696,10 +698,10 @@ namespace SecurityCodeScan.Analyzers.Taint
 
                 var argumentToSearch = adjustedArgumentIdx;
                 if (methodSymbol != null                           &&
-                    i            >= methodSymbol.Parameters.Length &&
-                    methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
+                    i            >= methodParameterCount &&
+                    reducedMethodSymbol.Parameters[methodParameterCount - 1].IsParams)
                 {
-                    argumentToSearch = isExtensionMethod ? methodSymbol.Parameters.Length : methodSymbol.Parameters.Length - 1;
+                    argumentToSearch = methodParameterCount - 1;
                 }
 
                 if (returnPostCondition == null ||
@@ -746,12 +748,12 @@ namespace SecurityCodeScan.Analyzers.Taint
                     }
                     else if (methodSymbol != null)
                     {
-                        if (trueArgIx >= methodSymbol.Parameters.Length)
+                        if (trueArgIx >= methodParameterCount)
                         {
-                            if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
+                            if (!reducedMethodSymbol.Parameters[methodParameterCount - 1].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[trueArgIx].RefKind != RefKind.None)
+                        else if (reducedMethodSymbol.Parameters[trueArgIx].RefKind != RefKind.None)
                         {
                             argumentStates[trueArgIx].MergeTaint(returnState.Taint);
                         }
@@ -763,7 +765,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                 methodSymbol != null &&
                 methodSymbol.ReturnsVoid &&
                 !methodSymbol.IsStatic &&
-                methodSymbol.Parameters.All(x => x.RefKind == RefKind.None))
+                reducedMethodSymbol.Parameters.All(x => x.RefKind == RefKind.None))
             {
                 memberVariableState.MergeTaint(returnState.Taint);
             }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -650,17 +650,17 @@ namespace SecurityCodeScan.Analyzers.Taint
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
                                   methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[methodSymbol.Parameters.Length]
+                                     ? new VariableState[(methodSymbol.ReducedFrom ?? methodSymbol).Parameters.Length]
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
             {
-                var argument      = argList.Arguments[i];
+                var argument = argList.Arguments[i];
 
                 var adjustedArgumentIdx = methodSymbol?.FindArgumentIndex(i, argument) ?? i;
 
                 var argumentState = VisitExpression(argument.Expression, state);
-                if (argumentStates != null)
+                if (argumentStates != null && adjustedArgumentIdx < argumentStates.Length)
                     argumentStates[adjustedArgumentIdx] = argumentState;
 
 #if DEBUG

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -650,7 +650,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
                                   methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[argCount.Value]
+                                     ? new Dictionary<int, VariableState>(argCount.Value)
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
@@ -663,7 +663,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                     ++adjustedArgumentIdx;
 
                 if (argumentStates != null)
-                    argumentStates[i] = argumentState;
+                    argumentStates[adjustedArgumentIdx] = argumentState;
 
 #if DEBUG
                 Logger.Log(symbol.ContainingType + "." + symbol.Name + " -> " + argumentState);
@@ -730,30 +730,31 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             if (argumentStates != null)
             {
-                for (var i = 0; i < argList.Arguments.Count; i++)
+                foreach(var arg in argumentStates)
                 {
-                    var adjustedPostConditionIdx = isExtensionMethod ? i + 1 : i;
-
-                    if (postConditions != null && postConditions.TryGetValue(adjustedPostConditionIdx, out var postCondition) )
+                    if (postConditions != null && postConditions.TryGetValue(arg.Key, out var postCondition))
                     {
                         foreach (var argIdx in postCondition.TaintFromArguments)
                         {
                             var adjustedArgumentIdx = isExtensionMethod ? argIdx + 1 : argIdx;
-                            argumentStates[adjustedPostConditionIdx].MergeTaint(argumentStates[adjustedArgumentIdx].Taint);
+                            if (!argumentStates.TryGetValue(adjustedArgumentIdx, out var postConditionStateSource))
+                                continue;
+
+                            arg.Value.MergeTaint(postConditionStateSource.Taint);
                         }
 
-                        argumentStates[adjustedPostConditionIdx].ApplyTaint(postCondition.Taint);
+                        arg.Value.ApplyTaint(postCondition.Taint);
                     }
                     else if (methodSymbol != null)
                     {
-                        if (i >= methodSymbol.Parameters.Length)
+                        if (arg.Key >= methodSymbol.Parameters.Length)
                         {
                             if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[i].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[arg.Key].RefKind != RefKind.None)
                         {
-                            argumentStates[i].MergeTaint(returnState.Taint);
+                            arg.Value.MergeTaint(returnState.Taint);
                         }
                     }
                 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -650,21 +650,22 @@ namespace SecurityCodeScan.Analyzers.Taint
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
                                   methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[argCount.Value]
+                                     ? new VariableState[methodSymbol.Parameters.Length]
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
             {
                 var argument      = argList.Arguments[i];
+
+                var adjustedArgumentIdx = methodSymbol?.FindArgumentIndex(i, argument) ?? i;
+
                 var argumentState = VisitExpression(argument.Expression, state);
                 if (argumentStates != null)
-                    argumentStates[i] = argumentState;
+                    argumentStates[adjustedArgumentIdx] = argumentState;
 
 #if DEBUG
                 Logger.Log(symbol.ContainingType + "." + symbol.Name + " -> " + argumentState);
 #endif
-
-                var adjustedArgumentIdx = isExtensionMethod ? i + 1 : i;
 
                 if (behavior != null)
                 {
@@ -727,30 +728,32 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             if (argumentStates != null)
             {
-                for (var i = 0; i < argList.Arguments.Count; i++)
+                for (var trueArgIx = 0; trueArgIx < argumentStates.Length; trueArgIx++)
                 {
-                    var adjustedPostConditionIdx = isExtensionMethod ? i + 1 : i;
+                    // wasn't initialized
+                    if (argumentStates[trueArgIx] == null)
+                        continue;
 
-                    if (postConditions != null && postConditions.TryGetValue(adjustedPostConditionIdx, out var postCondition) )
+                    if (postConditions != null && postConditions.TryGetValue(trueArgIx, out var postCondition) )
                     {
                         foreach (var argIdx in postCondition.TaintFromArguments)
                         {
                             var adjustedArgumentIdx = isExtensionMethod ? argIdx + 1 : argIdx;
-                            argumentStates[adjustedPostConditionIdx].MergeTaint(argumentStates[adjustedArgumentIdx].Taint);
+                            argumentStates[trueArgIx].MergeTaint(argumentStates[adjustedArgumentIdx].Taint);
                         }
 
-                        argumentStates[adjustedPostConditionIdx].ApplyTaint(postCondition.Taint);
+                        argumentStates[trueArgIx].ApplyTaint(postCondition.Taint);
                     }
                     else if (methodSymbol != null)
                     {
-                        if (i >= methodSymbol.Parameters.Length)
+                        if (trueArgIx >= methodSymbol.Parameters.Length)
                         {
                             if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[i].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[trueArgIx].RefKind != RefKind.None)
                         {
-                            argumentStates[i].MergeTaint(returnState.Taint);
+                            argumentStates[trueArgIx].MergeTaint(returnState.Taint);
                         }
                     }
                 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -636,7 +636,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
                                   methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[argCount.Value]
+                                     ? new Dictionary<int, VariableState>(argCount.Value)
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
@@ -649,7 +649,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                     ++adjustedArgumentIdx;
 
                 if (argumentStates != null)
-                    argumentStates[i] = argumentState;
+                    argumentStates[adjustedArgumentIdx] = argumentState;
 
 #if DEBUG
                 Logger.Log(symbol.ContainingType + "." + symbol.Name + " -> " + argumentState);
@@ -706,30 +706,31 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             if (argumentStates != null)
             {
-                for (var i = 0; i < argList.Arguments.Count; i++)
+                foreach (var arg in argumentStates)
                 {
-                    var adjustedPostConditionIdx = isExtensionMethod ? i + 1 : i;
-
-                    if (postConditions != null && postConditions.TryGetValue(adjustedPostConditionIdx, out var postCondition))
+                    if (postConditions != null && postConditions.TryGetValue(arg.Key, out var postCondition))
                     {
                         foreach (var argIdx in postCondition.TaintFromArguments)
                         {
                             var adjustedArgumentIdx = isExtensionMethod ? argIdx + 1 : argIdx;
-                            argumentStates[adjustedPostConditionIdx].MergeTaint(argumentStates[adjustedArgumentIdx].Taint);
+                            if (!argumentStates.TryGetValue(adjustedArgumentIdx, out var postConditionStateSource))
+                                continue;
+
+                            arg.Value.MergeTaint(postConditionStateSource.Taint);
                         }
 
-                        argumentStates[adjustedPostConditionIdx].ApplyTaint(postCondition.Taint);
+                        arg.Value.ApplyTaint(postCondition.Taint);
                     }
                     else if (methodSymbol != null)
                     {
-                        if (i >= methodSymbol.Parameters.Length)
+                        if (arg.Key >= methodSymbol.Parameters.Length)
                         {
                             if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[i].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[arg.Key].RefKind != RefKind.None)
                         {
-                            argumentStates[i].MergeTaint(returnState.Taint);
+                            arg.Value.MergeTaint(returnState.Taint);
                         }
                     }
                 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -631,7 +631,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                                                                           ? VariableTaint.Unset
                                                                           : VariableTaint.Unknown);
 
-            var reducedMethodSymbol = (methodSymbol.ReducedFrom ?? methodSymbol);
+            var reducedMethodSymbol = (methodSymbol?.ReducedFrom ?? methodSymbol);
             var methodParameterCount = methodSymbol != null ? reducedMethodSymbol.Parameters.Length : 0;
             var argCount = argList?.Arguments.Count;
             var argumentStates = argCount.HasValue &&

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -636,7 +636,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
                                   methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[methodSymbol.Parameters.Length]
+                                     ? new VariableState[(methodSymbol.ReducedFrom ?? methodSymbol).Parameters.Length]
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
@@ -646,7 +646,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                 var adjustedArgumentIdx = methodSymbol?.FindArgumentIndex(i, argument) ?? i;
 
                 var argumentState = VisitExpression(argument.GetExpression(), state);
-                if (argumentStates != null)
+                if (argumentStates != null && adjustedArgumentIdx < argumentStates.Length)
                     argumentStates[i] = argumentState;
 
 #if DEBUG

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -631,24 +631,24 @@ namespace SecurityCodeScan.Analyzers.Taint
                                                                           ? VariableTaint.Unset
                                                                           : VariableTaint.Unknown);
 
-            var reducedMethodSymbol = (methodSymbol?.ReducedFrom ?? methodSymbol);
-            var methodParameterCount = methodSymbol != null ? reducedMethodSymbol.Parameters.Length : 0;
             var argCount = argList?.Arguments.Count;
             var argumentStates = argCount.HasValue &&
                                  argCount.Value > 0 &&
                                  (postConditions?.Any(c => c.Key != -1 && (c.Value.Taint != 0ul || c.Value.TaintFromArguments.Any())) == true ||
-                                  methodSymbol != null && reducedMethodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
-                                     ? new VariableState[methodParameterCount]
+                                  methodSymbol != null && methodSymbol.Parameters.Any(x => x.RefKind != RefKind.None))
+                                     ? new VariableState[argCount.Value]
                                      : null;
 
             for (var i = 0; i < argList?.Arguments.Count; i++)
             {
                 var argument      = argList.Arguments[i];
+                var argumentState = VisitExpression(argument.GetExpression(), state);
 
                 var adjustedArgumentIdx = methodSymbol?.FindArgumentIndex(i, argument) ?? i;
+                if (isExtensionMethod)
+                    ++adjustedArgumentIdx;
 
-                var argumentState = VisitExpression(argument.GetExpression(), state);
-                if (argumentStates != null && adjustedArgumentIdx < argumentStates.Length)
+                if (argumentStates != null)
                     argumentStates[i] = argumentState;
 
 #if DEBUG
@@ -684,10 +684,10 @@ namespace SecurityCodeScan.Analyzers.Taint
 
                 var argumentToSearch = adjustedArgumentIdx;
                 if (methodSymbol != null                           &&
-                    i            >= methodParameterCount &&
-                    reducedMethodSymbol.Parameters[methodParameterCount - 1].IsParams)
+                    i            >= methodSymbol.Parameters.Length &&
+                    methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
                 {
-                    argumentToSearch = methodParameterCount - 1;
+                    argumentToSearch = isExtensionMethod ? methodSymbol.Parameters.Length : methodSymbol.Parameters.Length - 1;
                 }
 
                 if (returnPostCondition == null ||
@@ -706,32 +706,30 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             if (argumentStates != null)
             {
-                for (var trueArgIx = 0; trueArgIx < argumentStates.Length; trueArgIx++)
+                for (var i = 0; i < argList.Arguments.Count; i++)
                 {
-                    // wasn't initialized
-                    if (argumentStates[trueArgIx] == null)
-                        continue;
+                    var adjustedPostConditionIdx = isExtensionMethod ? i + 1 : i;
 
-                    if (postConditions != null && postConditions.TryGetValue(trueArgIx, out var postCondition))
+                    if (postConditions != null && postConditions.TryGetValue(adjustedPostConditionIdx, out var postCondition))
                     {
                         foreach (var argIdx in postCondition.TaintFromArguments)
                         {
                             var adjustedArgumentIdx = isExtensionMethod ? argIdx + 1 : argIdx;
-                            argumentStates[trueArgIx].MergeTaint(argumentStates[adjustedArgumentIdx].Taint);
+                            argumentStates[adjustedPostConditionIdx].MergeTaint(argumentStates[adjustedArgumentIdx].Taint);
                         }
 
-                        argumentStates[trueArgIx].ApplyTaint(postCondition.Taint);
+                        argumentStates[adjustedPostConditionIdx].ApplyTaint(postCondition.Taint);
                     }
                     else if (methodSymbol != null)
                     {
-                        if (trueArgIx >= methodParameterCount)
+                        if (i >= methodSymbol.Parameters.Length)
                         {
-                            if (!reducedMethodSymbol.Parameters[methodParameterCount - 1].IsParams)
+                            if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (reducedMethodSymbol.Parameters[trueArgIx].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[i].RefKind != RefKind.None)
                         {
-                            argumentStates[trueArgIx].MergeTaint(returnState.Taint);
+                            argumentStates[i].MergeTaint(returnState.Taint);
                         }
                     }
                 }
@@ -741,7 +739,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                 methodSymbol        != null &&
                 methodSymbol.ReturnsVoid    &&
                 !methodSymbol.IsStatic      &&
-                reducedMethodSymbol.Parameters.All(x => x.RefKind == RefKind.None))
+                methodSymbol.Parameters.All(x => x.RefKind == RefKind.None))
             {
                 memberVariableState.MergeTaint(returnState.Taint);
             }

--- a/SecurityCodeScan/Analyzers/Utils/ISymbolExtensions.cs
+++ b/SecurityCodeScan/Analyzers/Utils/ISymbolExtensions.cs
@@ -7,7 +7,8 @@ namespace SecurityCodeScan.Analyzers.Utils
     {
         public static int? FindArgumentIndex(this IMethodSymbol method, int sourceIndex, Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax arg)
         {
-            if (method == null) return null;
+            if (method == null)
+                return null;
 
             if(arg.NameColon != null)
             {
@@ -16,7 +17,7 @@ namespace SecurityCodeScan.Analyzers.Utils
                 return method.FindArgumentIndexByName(argName);
             }
 
-            return method.GetTrueArgumentIndex(sourceIndex);
+            return sourceIndex;
         }
 
         public static int? FindArgumentIndex(this IMethodSymbol method, int sourceIndex, Microsoft.CodeAnalysis.VisualBasic.Syntax.ArgumentSyntax arg)
@@ -26,23 +27,10 @@ namespace SecurityCodeScan.Analyzers.Utils
 
             if (arg.IsNamed)
             {
-                var argName = (arg as Microsoft.CodeAnalysis.VisualBasic.Syntax.SimpleArgumentSyntax).NameColonEquals.Name.Identifier.ValueText;
+                var argName = ((Microsoft.CodeAnalysis.VisualBasic.Syntax.SimpleArgumentSyntax)arg).NameColonEquals.Name.Identifier.ValueText;
 
                 return method.FindArgumentIndexByName(argName);
             }
-
-            return method.GetTrueArgumentIndex(sourceIndex);
-        }
-
-        public static int? GetTrueArgumentIndex(this IMethodSymbol method, int sourceIndex)
-        {
-            if (method == null)
-                return null;
-
-            bool isExtensionMethod = method.ReducedFrom != null;
-
-            if (isExtensionMethod)
-                return 1 + sourceIndex;
 
             return sourceIndex;
         }


### PR DESCRIPTION
I noticed while looking into another potential change* that the `*CodeEvaluation`s get confused by named parameters if the parameter is not in it's default position.

Basically, if you have a method (and appropriate configuration)
```csharp
void TheSecondParameterIsInjectable(int foo, string bar);
```

the invocation

```csharp
TheSecondParameterIsInjectable(bar: scaryUserInput, foo: 123);
```
won't be flagged.  The reverse case (an erroneous flag) is also possible.

This PR fixes that (and adds [a small test](https://github.com/kevin-montrose/security-code-scan/blob/a043fefff6278007b9d57b09b67dca5fb10e319d/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs#L53)).

The logic is complicated, so I'm not _positive_ this is correct.  I'll poke at some more weird invocation-styles (optional parameters, and extension methods mixing all the types) if I can free up some time.  But since all tests are passing, this may already be ready to merge.

<sub>*I think making behavior application conditional (like the attributes in the Csrf branch) will cover a few remaining gnarly places in the Stack Overflow codebases, especially around redirects. 
 I'm not quite ready to submit that yet, however.</sub>