### PR TITLE
allow dynamic (no namespace) in ArgTypes, and add a test for it

### DIFF
--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -596,7 +596,7 @@ namespace SecurityCodeScan.Config
                         throw new Exception(
                             $"Leading or trailing white space in argument of {nameSpace}.{className}.{name}");
 
-                    if (!argType.Contains("."))
+                    if (!argType.Contains(".") && !argType.Equals("dynamic"))
                         throw new Exception($"Argument type lacks namespace in {nameSpace}.{className}.{name}");
 
                     if (argType.Contains("this "))


### PR DESCRIPTION
Currently configurations expected all arguments in an `ArgType` to contain a namespace.  This is correct _except_ for methods taking `dynamic` in C# (VB.NET has no equivalent that I'm aware of).

The rest of the code seems to deal with `dynamic` just fine, so all this PR does is add a test and explicitly allow `dynamic` in `Configuration.ValidateArgTypes(...)`.