### PR TITLE
Fix taint tracking out of bounds indexing for extension methods with ref-like parameters

### DIFF
--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -2767,5 +2767,38 @@ Behavior:
             await VerifyCSharpDiagnostic(cSharpTest, null, optionsWithProjectConfig).ConfigureAwait(false);
             await VerifyVisualBasicDiagnostic(visualBasicTest, null, optionsWithProjectConfig).ConfigureAwait(false);
         }
+
+        [TestMethod]
+        [TestCategory("Safe")]
+        public async Task ExtensionMethodWithRef()
+        {
+            var cSharpTest = @"
+class Test
+{
+    public void Foo(string bar)
+    {
+        int c = 1;
+        bar.ExtensionMethodRef(ref c);
+        int d;
+        bar.ExtensionMethodOut(out d);
+    }
+}
+
+static class Exts
+{
+    public static void ExtensionMethodRef(this string str, ref int a)
+    {
+        a = str.Length;
+    }
+
+    public static void ExtensionMethodOut(this string str, out int a)
+    {
+        a = str.Length;
+    }
+}
+";
+
+            await VerifyCSharpDiagnostic(cSharpTest).ConfigureAwait(false);
+        }
     }
 }

--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -2798,7 +2798,34 @@ static class Exts
 }
 ";
 
+            var vbTest = @"
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+Class Test
+    Public Sub Foo(ByVal bar As String)
+        Dim c As Integer = 1
+        bar.ExtensionMethodRef(c)
+        Dim d As Integer
+        bar.ExtensionMethodOut(d)
+    End Sub
+End Class
+
+Module Exts
+    <Extension()>
+    Sub ExtensionMethodRef(ByVal str As String, ByRef a As Integer)
+        a = str.Length
+    End Sub
+
+    <Extension()>
+    Sub ExtensionMethodOut(ByVal str As String, <Out> ByRef a As Integer)
+        a = str.Length
+    End Sub
+End Module
+";
+
             await VerifyCSharpDiagnostic(cSharpTest).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(vbTest).ConfigureAwait(false);
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -747,12 +747,14 @@ namespace SecurityCodeScan.Analyzers.Taint
                     }
                     else if (methodSymbol != null)
                     {
-                        if (arg.Key >= methodSymbol.Parameters.Length)
+                        var adjustedArgIx = isExtensionMethod ? arg.Key - 1 : arg.Key;
+
+                        if (adjustedArgIx >= methodSymbol.Parameters.Length)
                         {
-                            if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
+                            if (!methodSymbol.Parameters[adjustedArgIx].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[arg.Key].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[adjustedArgIx].RefKind != RefKind.None)
                         {
                             arg.Value.MergeTaint(returnState.Taint);
                         }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -723,12 +723,14 @@ namespace SecurityCodeScan.Analyzers.Taint
                     }
                     else if (methodSymbol != null)
                     {
-                        if (arg.Key >= methodSymbol.Parameters.Length)
+                        var adjustedArgIx = isExtensionMethod ? arg.Key - 1 : arg.Key;
+
+                        if (adjustedArgIx >= methodSymbol.Parameters.Length)
                         {
-                            if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
+                            if (!methodSymbol.Parameters[adjustedArgIx].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[arg.Key].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[adjustedArgIx].RefKind != RefKind.None)
                         {
                             arg.Value.MergeTaint(returnState.Taint);
                         }


### PR DESCRIPTION
When running taint analysis, calls to extension methods with ref-like (ie. `ref` or `in`) parameters can fail with an IndexOutOfRangeException.  This is caused by not taking into account the extension methods implicit first parameter.

This PR adds a small test and fixes the issue.

I'm tempted to do a more substantial reworking, but this is feels worth fixing on its own.