### PR TITLE
Fix taint tracking out of bounds indexing for extension methods with ref-like parameters

### DIFF
--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -2795,7 +2795,34 @@ static class Exts
 }
 ";
 
+            var vbTest = @"
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+Class Test
+    Public Sub Foo(ByVal bar As String)
+        Dim c As Integer = 1
+        bar.ExtensionMethodRef(c)
+        Dim d As Integer
+        bar.ExtensionMethodOut(d)
+    End Sub
+End Class
+
+Module Exts
+    <Extension()>
+    Sub ExtensionMethodRef(ByVal str As String, ByRef a As Integer)
+        a = str.Length
+    End Sub
+
+    <Extension()>
+    Sub ExtensionMethodOut(ByVal str As String, <Out> ByRef a As Integer)
+        a = str.Length
+    End Sub
+End Module
+";
+
             await VerifyCSharpDiagnostic(cSharpTest).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(vbTest).ConfigureAwait(false);
         }
     }
 }

--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -2764,5 +2764,38 @@ Behavior:
             await VerifyCSharpDiagnostic(cSharpTest, null, optionsWithProjectConfig).ConfigureAwait(false);
             await VerifyVisualBasicDiagnostic(visualBasicTest, null, optionsWithProjectConfig).ConfigureAwait(false);
         }
+
+        [TestMethod]
+        [TestCategory("Safe")]
+        public async Task ExtensionMethodWithRef()
+        {
+            var cSharpTest = @"
+class Test
+{
+    public void Foo(string bar)
+    {
+        int c = 1;
+        bar.ExtensionMethodRef(ref c);
+        int d;
+        bar.ExtensionMethodOut(out d);
+    }
+}
+
+static class Exts
+{
+    public static void ExtensionMethodRef(this string str, ref int a)
+    {
+        a = str.Length;
+    }
+
+    public static void ExtensionMethodOut(this string str, out int a)
+    {
+        a = str.Length;
+    }
+}
+";
+
+            await VerifyCSharpDiagnostic(cSharpTest).ConfigureAwait(false);
+        }
     }
 }

--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -2824,5 +2824,157 @@ End Module
             await VerifyCSharpDiagnostic(cSharpTest).ConfigureAwait(false);
             await VerifyVisualBasicDiagnostic(vbTest).ConfigureAwait(false);
         }
+
+        [TestMethod]
+        [TestCategory("Detect")]
+        public async Task ExtensionMethodWithPostCondition()
+        {
+            var cSharpTest = @"
+class Test
+{
+    public void Foo(string userInput)
+    {
+        string foo = """";
+        userInput.ExtensionMethodRef(ref foo);
+        Sink(foo);
+    }
+
+    private void Sink(string input)
+    {
+    }
+}
+
+static class Exts
+{
+    public static void ExtensionMethodRef(this string str, ref string a)
+    {
+        a += str;
+    }
+}
+";
+
+            var vbTest = @"
+Imports System.Runtime.CompilerServices
+
+Class Test
+    Public Sub Foo(ByVal userInput As String)
+        Dim foo As String = ""
+        ""
+        userInput.ExtensionMethodRef(foo)
+        Sink(foo)
+    End Sub
+
+    Private Sub Sink(ByVal input As String)
+    End Sub
+End Class
+
+Module Exts
+    <Extension()>
+    Sub ExtensionMethodRef(ByVal str As String, ByRef a As String)
+        a += str
+    End Sub
+End Module
+";
+
+            var testConfig = @"
+TaintEntryPoints:
+  Test:
+    ClassName: Test
+
+Behavior:
+  123:
+    ClassName: Exts
+    Name: ExtensionMethodRef
+    Method:
+      1:
+        TaintFromArguments: [0]
+
+  MyKey:
+    ClassName: Test
+    Name: Sink
+    Method:
+      InjectableArguments: [SCS0026: 0]
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(vbTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("Detect")]
+        public async Task ExtensionMethodWithPostCondition2()
+        {
+            var cSharpTest = @"
+class Test
+{
+    public void Foo(string userInput)
+    {
+        string foo = """";
+        userInput.ExtensionMethodRef(ref foo, userInput);
+        Sink(foo);
+    }
+
+    private void Sink(string input)
+    {
+    }
+}
+
+static class Exts
+{
+    public static void ExtensionMethodRef(this string str, ref string a, string b)
+    {
+        a += b;
+    }
+}
+";
+
+            var vbTest = @"
+Imports System.Runtime.CompilerServices
+
+Class Test
+    Public Sub Foo(ByVal userInput As String)
+        Dim foo As String = ""
+        ""
+        userInput.ExtensionMethodRef(foo, userInput)
+        Sink(foo)
+    End Sub
+
+    Private Sub Sink(ByVal input As String)
+    End Sub
+End Class
+
+Module Exts
+    <Extension()>
+    Sub ExtensionMethodRef(ByVal str As String, ByRef a As String, ByVal b As String)
+        a += b
+    End Sub
+End Module
+";
+
+            var testConfig = @"
+TaintEntryPoints:
+  Test:
+    ClassName: Test
+
+Behavior:
+  123:
+    ClassName: Exts
+    Name: ExtensionMethodRef
+    Method:
+      1:
+        TaintFromArguments: [2]
+
+  MyKey:
+    ClassName: Test
+    Name: Sink
+    Method:
+      InjectableArguments: [SCS0026: 0]
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(vbTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+        }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -721,12 +721,14 @@ namespace SecurityCodeScan.Analyzers.Taint
                     }
                     else if (methodSymbol != null)
                     {
-                        if (arg.Key >= methodSymbol.Parameters.Length)
+                        var adjustedArgIx = isExtensionMethod ? arg.Key - 1 : arg.Key;
+
+                        if (adjustedArgIx >= methodSymbol.Parameters.Length)
                         {
-                            if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
+                            if (!methodSymbol.Parameters[adjustedArgIx].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[arg.Key].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[adjustedArgIx].RefKind != RefKind.None)
                         {
                             arg.Value.MergeTaint(returnState.Taint);
                         }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -710,8 +710,13 @@ namespace SecurityCodeScan.Analyzers.Taint
                     {
                         foreach (var argIdx in postCondition.TaintFromArguments)
                         {
-                            var adjustedArgumentIdx = isExtensionMethod ? argIdx + 1 : argIdx;
-                            if (!argumentStates.TryGetValue(adjustedArgumentIdx, out var postConditionStateSource))
+                            if (isExtensionMethod && argIdx == 0)
+                            {
+                                arg.Value.MergeTaint(initialTaint.Value); // shouldn't be null, otherwise fail early
+                                continue;
+                            }
+
+                            if (!argumentStates.TryGetValue(argIdx, out var postConditionStateSource))
                                 continue;
 
                             arg.Value.MergeTaint(postConditionStateSource.Taint);

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -721,12 +721,14 @@ namespace SecurityCodeScan.Analyzers.Taint
                     }
                     else if (methodSymbol != null)
                     {
-                        if (arg.Key >= methodSymbol.Parameters.Length)
+                        var adjustedArgIx = isExtensionMethod ? arg.Key - 1 : arg.Key;
+
+                        if (adjustedArgIx >= methodSymbol.Parameters.Length)
                         {
-                            if (!methodSymbol.Parameters[methodSymbol.Parameters.Length - 1].IsParams)
+                            if (!methodSymbol.Parameters[adjustedArgIx].IsParams)
                                 throw new IndexOutOfRangeException();
                         }
-                        else if (methodSymbol.Parameters[arg.Key].RefKind != RefKind.None)
+                        else if (methodSymbol.Parameters[adjustedArgIx].RefKind != RefKind.None)
                         {
                             arg.Value.MergeTaint(returnState.Taint);
                         }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -710,8 +710,13 @@ namespace SecurityCodeScan.Analyzers.Taint
                     {
                         foreach (var argIdx in postCondition.TaintFromArguments)
                         {
-                            var adjustedArgumentIdx = isExtensionMethod ? argIdx + 1 : argIdx;
-                            if (!argumentStates.TryGetValue(adjustedArgumentIdx, out var postConditionStateSource))
+                            if (isExtensionMethod && argIdx == 0)
+                            {
+                                arg.Value.MergeTaint(initialTaint.Value); // shouldn't be null, otherwise fail early
+                                continue;
+                            }
+
+                            if (!argumentStates.TryGetValue(argIdx, out var postConditionStateSource))
                                 continue;
 
                             arg.Value.MergeTaint(postConditionStateSource.Taint);


### PR DESCRIPTION
Version of https://github.com/security-code-scan/security-code-scan/pull/134 against master.

For some reason tests really do not like running on my machine, but... should be fine?

---

When running taint analysis, calls to extension methods with ref-like (ie. ref or in) parameters can fail with an IndexOutOfRangeException. This is caused by not taking into account the extension methods implicit first parameter.

This PR adds a small test and fixes the issue.

I'm tempted to do a more substantial reworking, but this is feels worth fixing on its own.