### PR TITLE
Conditional application of InjectableArguments

### DIFF
--- a/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs
@@ -324,5 +324,167 @@ End Class
             await VerifyCSharpDiagnostic(cSharpTest2).ConfigureAwait(false);
             await VerifyVisualBasicDiagnostic(visualBasicTest).ConfigureAwait(false);
         }
+
+        [TestCategory("Detect")]
+        [TestMethod]
+        public async Task ConditionalOpenRedirect()
+        {
+            var cSharpTest1 = @"
+using Microsoft.AspNetCore.Mvc;
+
+class OpenRedirect : Controller
+{
+    public ActionResult Vulnerable(string scary)
+    {
+        return ConditionalRedirect(scary, false);
+    }
+
+    public ActionResult Safe(string notScary)
+    {
+        return ConditionalRedirect(notScary, true);
+    }
+
+    private ActionResult ConditionalRedirect(string url, bool internalOnly)
+    {
+        // pretend this does something
+        return null;
+    }
+}
+";
+            var cSharpTest2 = @"
+using Microsoft.AspNetCore.Mvc;
+
+class OpenRedirect : Controller
+{
+    public ActionResult Vulnerable(string scary1)
+    {
+        return ConditionalRedirect(scary1, false);
+    }
+
+    public ActionResult VulnerableNamed(string scary2)
+    {
+        return ConditionalRedirect(internalOnly: false, url: scary2);
+    }
+
+    public ActionResult Safe(string notScary1)
+    {
+        return ConditionalRedirect(notScary1);
+    }
+
+    public ActionResult SafeNamed1(string notScary2)
+    {
+        return ConditionalRedirect(url: notScary2);
+    }
+
+    public ActionResult SafeNamed2(string notScary3)
+    {
+        return ConditionalRedirect(internalOnly: true, url: notScary3);
+    }
+
+    private ActionResult ConditionalRedirect(string url, bool internalOnly = true)
+    {
+        // pretend this does something
+        return null;
+    }
+}
+";
+
+            var vbTest1 = @"
+Imports Microsoft.AspNetCore.Mvc
+
+Class OpenRedirect
+    Inherits Controller
+
+    Public Function Vulnerable(ByVal scary As String) As ActionResult
+        Return ConditionalRedirect(scary, False)
+    End Function
+
+    Public Function Safe(ByVal notScary As String) As ActionResult
+        Return ConditionalRedirect(notScary, True)
+    End Function
+
+    Private Function ConditionalRedirect(ByVal url As String, ByVal internalOnly As Boolean) As ActionResult
+        Return Nothing
+    End Function
+End Class
+";
+
+            var vbTest2 = @"
+Imports Microsoft.AspNetCore.Mvc
+
+Class OpenRedirect
+    Inherits Controller
+
+    Public Function Vulnerable(ByVal scary1 As String) As ActionResult
+        Return ConditionalRedirect(scary1, False)
+    End Function
+
+    Public Function VulnerableNamed(ByVal scary2 As String) As ActionResult
+        Return ConditionalRedirect(internalOnly:=False, url:=scary2)
+    End Function
+
+    Public Function Safe(ByVal notScary1 As String) As ActionResult
+        Return ConditionalRedirect(notScary1)
+    End Function
+
+    Public Function SafeNamed1(ByVal notScary2 As String) As ActionResult
+        Return ConditionalRedirect(url:=notScary2)
+    End Function
+
+    Public Function SafeNamed2(ByVal notScary3 As String) As ActionResult
+        Return ConditionalRedirect(internalOnly:=True, url:=notScary3)
+    End Function
+
+    Private Function ConditionalRedirect(ByVal url As String, ByVal Optional internalOnly As Boolean = True) As ActionResult
+        Return Nothing
+    End Function
+End Class
+
+";
+
+
+            var testConfig = @"
+Behavior:
+
+  Conditional:
+    ClassName: OpenRedirect
+    Name: ConditionalRedirect
+    Method:
+      Condition: {1: { Value: False } }
+      ArgTypes: (System.String, System.Boolean)
+      InjectableArguments: [SCS0027: 0]
+";
+
+            var expectedCSharp1 =
+                new[]
+                {
+                    Expected.WithLocation(8, 36)
+                };
+
+            var expectedCSharp2 =
+                new[]
+                {
+                    Expected.WithLocation(8, 36),
+                    Expected.WithLocation(13, 62)
+                };
+            var expectedVB1 =
+                new[]
+                {
+                    Expected.WithLocation(8, 36)
+                };
+            var expectedVB2 =
+                new[]
+                {
+                    Expected.WithLocation(8, 36),
+                    Expected.WithLocation(12, 62)
+                };
+
+            var config = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest1, expectedCSharp1, options: config).ConfigureAwait(false);
+            await VerifyCSharpDiagnostic(cSharpTest2, expectedCSharp2, options: config).ConfigureAwait(false);
+
+            await VerifyVisualBasicDiagnostic(vbTest1, expectedVB1, options: config).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(vbTest2, expectedVB2, options: config).ConfigureAwait(false);
+        }
     }
 }

--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -58,13 +58,11 @@ class Test
         if (output == null)
             return;
     }
-
     public void Injectable(string input)
     {
         // pretend it does something
     }
 }
-
 class TestInput
 {
     public void Input(string userProvided)
@@ -82,11 +80,9 @@ Class Test
     Public Sub Encode(ByVal input As String, ByVal Optional x As Integer = 0, ByVal Optional output As System.Text.StringBuilder = Nothing)
         If output Is Nothing Then Return
     End Sub
-
     Public Sub Injectable(ByVal input As String)
     End Sub
 End Class
-
 Class TestInput
     Public Sub Input(ByVal userProvided As String)
         Dim t = New Test()
@@ -110,7 +106,6 @@ Behavior:
     Method:
       2:
         TaintFromArguments: [0]
-
 TaintEntryPoints:
   Test:
     ClassName: TestInput
@@ -118,40 +113,40 @@ TaintEntryPoints:
 
             var testConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(config);
 
-            await VerifyCSharpDiagnostic(cSharpTest, Expected.WithLocation(23), testConfig).ConfigureAwait(false);
-            await VerifyVisualBasicDiagnostic(vbTest, Expected.WithLocation(16), testConfig).ConfigureAwait(false);
+            await VerifyCSharpDiagnostic(cSharpTest, Expected.WithLocation(21), testConfig).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(vbTest, Expected.WithLocation(14), testConfig).ConfigureAwait(false);
         }
 
         [DataTestMethod]
-        [DataRow("Injectable", "userProvided, userProvided",          true)]
-        [DataRow("Injectable", "\"\", userProvided",                  false)]
-        [DataRow("Injectable", "userProvided, \"\"",                  true)]
-        [DataRow("Injectable", "\"\", \"\"",                          false)]
-        [DataRow("Injectable", "dangerous: userProvided, safe: \"\"", true)]
-        [DataRow("Injectable", "dangerous: \"\", safe: userProvided", false)]
-        [DataRow("Injectable", "safe: userProvided, dangerous: \"\"", false)]
-        [DataRow("Injectable", "safe: \"\", dangerous: userProvided", true)]
+        [DataRow("Injectable", "userProvided, userProvided",            true)]
+        [DataRow("Injectable", "\"\", userProvided",                    false)]
+        [DataRow("Injectable", "userProvided, \"\"",                    true)]
+        [DataRow("Injectable", "\"\", \"\"",                            false)]
+        [DataRow("Injectable", "dangerous: userProvided, safe: \"\"",   true)]
+        [DataRow("Injectable", "dangerous: \"\", safe: userProvided",   false)]
+        [DataRow("Injectable", "safe: userProvided, dangerous: \"\"",   false)]
+        [DataRow("Injectable", "safe: \"\", dangerous: userProvided",   true)]
 
-        [DataRow("Injectable2", "userProvided, userProvided",          true)]
-        [DataRow("Injectable2", "\"\", userProvided",                  false)]
-        [DataRow("Injectable2", "userProvided, \"\"",                  true)]
-        [DataRow("Injectable2", "\"\", \"\"",                          false)]
-        [DataRow("Injectable2", "dangerous: userProvided, safe: \"\"", true)]
-        [DataRow("Injectable2", "dangerous: \"\", safe: userProvided", false)]
-        [DataRow("Injectable2", "safe: userProvided, dangerous: \"\"", false)]
-        [DataRow("Injectable2", "safe: \"\", dangerous: userProvided", true)]
+        [DataRow("Injectable2", "userProvided, userProvided",           true)]
+        [DataRow("Injectable2", "\"\", userProvided",                   false)]
+        [DataRow("Injectable2", "userProvided, \"\"",                   true)]
+        [DataRow("Injectable2", "\"\", \"\"",                           false)]
+        [DataRow("Injectable2", "dangerous: userProvided, safe: \"\"",  true)]
+        [DataRow("Injectable2", "dangerous: \"\", safe: userProvided",  false)]
+        [DataRow("Injectable2", "safe: userProvided, dangerous: \"\"",  false)]
+        [DataRow("Injectable2", "safe: \"\", dangerous: userProvided",  true)]
 
-        [DataRow("InjectableOpt", "",                           false)]
-        [DataRow("InjectableOpt", "userProvided, userProvided", true)]
-        [DataRow("InjectableOpt", "safe: userProvided",         false)]
-        [DataRow("InjectableOpt", "dangerous: userProvided",    true)]
-        [DataRow("InjectableOpt", "dangerous: \"\"",            false)]
+        [DataRow("InjectableOpt", "",                                   false)]
+        [DataRow("InjectableOpt", "userProvided, userProvided",         true)]
+        [DataRow("InjectableOpt", "safe: userProvided",                 false)]
+        [DataRow("InjectableOpt", "dangerous: userProvided",            true)]
+        [DataRow("InjectableOpt", "dangerous: \"\"",                    false)]
 
-        [DataRow("InjectableOpt2", "",                           false)]
-        [DataRow("InjectableOpt2", "userProvided, userProvided", true)]
-        [DataRow("InjectableOpt2", "safe: userProvided",         false)]
-        [DataRow("InjectableOpt2", "dangerous: userProvided",    true)]
-        [DataRow("InjectableOpt2", "dangerous: \"\"",            false)]
+        [DataRow("InjectableOpt2", "",                                  false)]
+        [DataRow("InjectableOpt2", "userProvided, userProvided",        true)]
+        [DataRow("InjectableOpt2", "safe: userProvided",                false)]
+        [DataRow("InjectableOpt2", "dangerous: userProvided",           true)]
+        [DataRow("InjectableOpt2", "dangerous: \"\"",                   false)]
         public async Task NamedArguments(string function, string payload, bool warn)
         {
             var cSharpTest = $@"
@@ -161,26 +156,22 @@ class Test
     {{
         // pretend it does something
     }}
-
     public void InjectableOpt(string dangerous=""foo"", string safe=""bar"")
     {{
         // pretend it does something
     }}
 }}
-
 static class TestExtensions
 {{
     public static void Injectable2(this Test self, string dangerous, string safe)
     {{
         // pretend it does something
     }}
-
     public static void InjectableOpt2(this Test self, string dangerous=""foo"", string safe=""bar"")
     {{
         // pretend it does something
     }}
 }}
-
 class TestInput
 {{
     public void Input(string userProvided)
@@ -195,25 +186,20 @@ class TestInput
 
             var vbTest = $@"
 Imports System.Runtime.CompilerServices
-
 Class Test
     Public Sub Injectable(ByVal dangerous As String, ByVal safe As String)
     End Sub
-
     Public Sub InjectableOpt(ByVal Optional dangerous As String = ""foo"", ByVal Optional safe As String = ""bar"")
     End Sub
 End Class
-
 Module TestExtensions
     <Extension()>
     Public Sub Injectable2(ByVal self As Test, ByVal dangerous As String, ByVal safe As String)
     End Sub
-
     <Extension()>
     Public Sub InjectableOpt2(ByVal self As Test, ByVal Optional dangerous As String = ""foo"", ByVal Optional safe As String = ""bar"")
     End Sub
 End Module
-
 Class TestInput
     Public Sub Input(ByVal userProvided As String)
         Dim a As New Test()
@@ -244,7 +230,6 @@ Behavior:
     Name: InjectableOpt2
     Method:
       InjectableArguments: [SCS0026: 1]
-
 TaintEntryPoints:
   Test:
     ClassName: TestInput
@@ -254,8 +239,8 @@ TaintEntryPoints:
 
             if (warn)
             {
-                await VerifyCSharpDiagnostic(cSharpTest, Expected.WithLocation(32), testConfig).ConfigureAwait(false);
-                await VerifyVisualBasicDiagnostic(vbTest, Expected.WithLocation(25), testConfig).ConfigureAwait(false);
+                await VerifyCSharpDiagnostic(cSharpTest, Expected.WithLocation(28), testConfig).ConfigureAwait(false);
+                await VerifyVisualBasicDiagnostic(vbTest, Expected.WithLocation(20), testConfig).ConfigureAwait(false);
             }
             else
             {

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -783,7 +783,6 @@ namespace SecurityCodeScan.Analyzers.Taint
 
                     if (p.HasExplicitDefaultValue)
                         codeVal = p.ExplicitDefaultValue;
-
                 }
 
                 // look at each arg, figure out if it changes the default

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -803,9 +803,10 @@ namespace SecurityCodeScan.Analyzers.Taint
                 lexicalIx++;
             }
 
-            foreach (int ix in condition.Keys)
+            foreach (var kv in condition)
             {
-                var val = (IReadOnlyDictionary<object, object>)condition[ix];
+                var ix = (int)kv.Key;
+                var val = (IReadOnlyDictionary<object, object>)kv.Value;
                 var expectedVal = val["Value"];
                 var codeVal = vals[ix];
 

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -812,11 +812,6 @@ namespace SecurityCodeScan.Analyzers.Taint
 
                 switch (expectedVal)
                 {
-                    case string expectValStr:
-                        if (!codeVal.Equals(expectedVal))
-                            return false;
-
-                        break;
                     case int expectedValInt:
                         if (!int.TryParse(codeVal, out var codeValInt) || codeValInt != expectedValInt)
                             return false;

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -764,12 +764,9 @@ namespace SecurityCodeScan.Analyzers.Taint
 
         private bool BehaviorApplies(IReadOnlyDictionary<object, object> condition, IMethodSymbol methodSymbol, SeparatedSyntaxList<ArgumentSyntax>? args, ExecutionState state)
         {
-            if (condition == null || condition.Count == 0)
+            if (condition == null || methodSymbol == null || condition.Count == 0)
                 return true;
-
-            if (methodSymbol == null)
-                return false;
-
+            
             var ps = methodSymbol.Parameters;
 
             var vals = new string[ps.Length];

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -770,7 +770,7 @@ namespace SecurityCodeScan.Analyzers.Taint
             if (methodSymbol == null)
                 return false;
 
-            var ps = methodSymbol.GetParameters();
+            var ps = methodSymbol.Parameters;
 
             var vals = new string[ps.Length];
             for(var i = 0; i < ps.Length; i++)

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -769,13 +769,13 @@ namespace SecurityCodeScan.Analyzers.Taint
             
             var ps = methodSymbol.Parameters;
 
-            var vals = new string[ps.Length];
+            var vals = new object[ps.Length];
             for(var i = 0; i < ps.Length; i++)
             {
                 var p = ps[i];
                 if(p.HasExplicitDefaultValue)
                 {
-                    vals[i] = p.ExplicitDefaultValue?.ToString();
+                    vals[i] = p.ExplicitDefaultValue;
                 }
                 else
                 {
@@ -793,7 +793,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                     var val = state.AnalysisContext.SemanticModel.GetConstantValue(arg.Expression);
                     if (val.HasValue)
                     {
-                        vals[destIx] = val.Value?.ToString();
+                        vals[destIx] = val.Value;
                     }
 
                     lexicalIx++;
@@ -807,25 +807,8 @@ namespace SecurityCodeScan.Analyzers.Taint
                 var expectedVal = val["Value"];
                 var codeVal = vals[ix];
 
-                if (codeVal == null)
+                if (!expectedVal.Equals(codeVal))
                     return false;
-
-                switch (expectedVal)
-                {
-                    case int expectedValInt:
-                        if (!int.TryParse(codeVal, out var codeValInt) || codeValInt != expectedValInt)
-                            return false;
-
-                        break;
-                    case bool expectedValBool:
-                        if (!bool.TryParse(codeVal, out var codeValBool) || codeValBool != expectedValBool)
-                            return false;
-
-                        break;
-                    default:
-                        // types are validated as part of parsing configuration, so this case should never be hit
-                        throw new InvalidOperationException("Condition value was not one of string, int, or bool; shouldn't be possible");
-                }
             }
 
             return true;

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -58,7 +58,9 @@ namespace SecurityCodeScan.Analyzers.Taint
                 Logger.Log(errorMsg);
                 if (e.InnerException != null)
                     Logger.Log($"{e.InnerException.Message}");
+
                 Logger.Log($"\n{e.StackTrace}", false);
+
                 throw;
             }
         }
@@ -627,6 +629,8 @@ namespace SecurityCodeScan.Analyzers.Taint
                                      ? new Dictionary<int, VariableState>(argCount.Value)
                                      : null;
 
+            var behaviorApplies = behavior != null && BehaviorApplies(behavior.AppliesUnderCondition, methodSymbol, argList?.Arguments, state);
+
             for (var i = 0; i < argList?.Arguments.Count; i++)
             {
                 var argument      = argList.Arguments[i];
@@ -642,8 +646,7 @@ namespace SecurityCodeScan.Analyzers.Taint
 #if DEBUG
                 Logger.Log(symbol.ContainingType + "." + symbol.Name + " -> " + argumentState);
 #endif
-
-                if (behavior != null)
+                if (behaviorApplies)
                 {
                     if ((argumentState.Taint & (ProjectConfiguration.AuditMode
                                                     ? VariableTaint.Tainted | VariableTaint.Unknown
@@ -757,6 +760,82 @@ namespace SecurityCodeScan.Analyzers.Taint
             }
 
             return returnState;
+        }
+
+        private bool BehaviorApplies(IReadOnlyDictionary<object, object> condition, IMethodSymbol methodSymbol, SeparatedSyntaxList<ArgumentSyntax>? args, ExecutionState state)
+        {
+            if (condition == null || condition.Count == 0)
+                return true;
+
+            if (methodSymbol == null)
+                return false;
+
+            if (args == null)
+                return false;
+
+            var ps = methodSymbol.GetParameters();
+
+            var vals = new string[ps.Length];
+            for(var i = 0; i < ps.Length; i++)
+            {
+                var p = ps[i];
+                if(p.HasExplicitDefaultValue)
+                {
+                    vals[i] = p.ExplicitDefaultValue?.ToString();
+                }
+                else
+                {
+                    vals[i] = null;
+                }
+            }
+
+            var lexicalIx = 0;
+            foreach (var arg in args)
+            {
+                var destIx = methodSymbol?.FindArgumentIndex(lexicalIx, arg) ?? lexicalIx;
+
+                var val = state.AnalysisContext.SemanticModel.GetConstantValue(arg.Expression);
+                if (val.HasValue)
+                {
+                    vals[destIx] = val.Value?.ToString();
+                }
+
+                lexicalIx++;
+            }
+
+            foreach (int ix in condition.Keys)
+            {
+                var val = (IReadOnlyDictionary<object, object>)condition[ix];
+                var expectedVal = val["Value"];
+                var codeVal = vals[ix];
+
+                if (codeVal == null)
+                    return false;
+
+                switch (expectedVal)
+                {
+                    case string expectValStr:
+                        if (!codeVal.Equals(expectedVal))
+                            return false;
+
+                        break;
+                    case int expectedValInt:
+                        if (!int.TryParse(codeVal, out var codeValInt) || codeValInt != expectedValInt)
+                            return false;
+
+                        break;
+                    case bool expectedValBool:
+                        if (!bool.TryParse(codeVal, out var codeValBool) || codeValBool != expectedValBool)
+                            return false;
+
+                        break;
+                    default:
+                        // types are validated as part of parsing configuration, so this case should never be hit
+                        throw new InvalidOperationException("Condition value was not one of string, int, or bool; shouldn't be possible");
+                }
+            }
+
+            return true;
         }
 
         private VariableState VisitAssignment(AssignmentExpressionSyntax node, ExecutionState state)

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -770,9 +770,6 @@ namespace SecurityCodeScan.Analyzers.Taint
             if (methodSymbol == null)
                 return false;
 
-            if (args == null)
-                return false;
-
             var ps = methodSymbol.GetParameters();
 
             var vals = new string[ps.Length];
@@ -789,18 +786,21 @@ namespace SecurityCodeScan.Analyzers.Taint
                 }
             }
 
-            var lexicalIx = 0;
-            foreach (var arg in args)
+            if (args != null)
             {
-                var destIx = methodSymbol?.FindArgumentIndex(lexicalIx, arg) ?? lexicalIx;
-
-                var val = state.AnalysisContext.SemanticModel.GetConstantValue(arg.Expression);
-                if (val.HasValue)
+                var lexicalIx = 0;
+                foreach (var arg in args)
                 {
-                    vals[destIx] = val.Value?.ToString();
-                }
+                    var destIx = methodSymbol?.FindArgumentIndex(lexicalIx, arg) ?? lexicalIx;
 
-                lexicalIx++;
+                    var val = state.AnalysisContext.SemanticModel.GetConstantValue(arg.Expression);
+                    if (val.HasValue)
+                    {
+                        vals[destIx] = val.Value?.ToString();
+                    }
+
+                    lexicalIx++;
+                }
             }
 
             foreach (var kv in condition)

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -821,11 +821,6 @@ namespace SecurityCodeScan.Analyzers.Taint
 
                 switch (expectedVal)
                 {
-                    case string expectValStr:
-                    if (!codeVal.Equals(expectedVal))
-                        return false;
-
-                    break;
                     case int expectedValInt:
                     if (!int.TryParse(codeVal, out var codeValInt) || codeValInt != expectedValInt)
                         return false;

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -768,14 +768,14 @@ namespace SecurityCodeScan.Analyzers.Taint
             
             var ps = methodSymbol.Parameters;
 
-            var vals = new string[ps.Length];
+            var vals = new object[ps.Length];
 
             for (var i = 0; i < ps.Length; i++)
             {
                 var p = ps[i];
                 if (p.HasExplicitDefaultValue)
                 {
-                    vals[i] = p.ExplicitDefaultValue?.ToString();
+                    vals[i] = p.ExplicitDefaultValue;
                 }
                 else
                 {
@@ -802,7 +802,7 @@ namespace SecurityCodeScan.Analyzers.Taint
 
                     if (val.HasValue)
                     {
-                        vals[destIx] = val.Value?.ToString();
+                        vals[destIx] = val.Value;
                     }
 
                     lexicalIx++;
@@ -816,25 +816,8 @@ namespace SecurityCodeScan.Analyzers.Taint
                 var expectedVal = val["Value"];
                 var codeVal = vals[ix];
 
-                if (codeVal == null)
+                if (!expectedVal.Equals(codeVal))
                     return false;
-
-                switch (expectedVal)
-                {
-                    case int expectedValInt:
-                    if (!int.TryParse(codeVal, out var codeValInt) || codeValInt != expectedValInt)
-                        return false;
-
-                    break;
-                    case bool expectedValBool:
-                    if (!bool.TryParse(codeVal, out var codeValBool) || codeValBool != expectedValBool)
-                        return false;
-
-                    break;
-                    default:
-                    // types are validated as part of parsing configuration, so this case should never be hit
-                    throw new InvalidOperationException("Condition value was not one of string, int, or bool; shouldn't be possible");
-                }
             }
 
             return true;

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -768,8 +768,8 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             if (methodSymbol == null)
                 return false;
-            
-            var ps = methodSymbol.GetParameters();
+
+            var ps = methodSymbol.Parameters;
 
             var vals = new string[ps.Length];
 

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -768,13 +768,11 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             if (methodSymbol == null)
                 return false;
-
-            if (args == null)
-                return false;
-
+            
             var ps = methodSymbol.GetParameters();
 
             var vals = new string[ps.Length];
+
             for (var i = 0; i < ps.Length; i++)
             {
                 var p = ps[i];
@@ -788,27 +786,30 @@ namespace SecurityCodeScan.Analyzers.Taint
                 }
             }
 
-            var lexicalIx = 0;
-            foreach (var arg in args)
+            if (args != null)
             {
-                var destIx = methodSymbol?.FindArgumentIndex(lexicalIx, arg) ?? lexicalIx;
-
-                Optional<object> val;
-                if(arg is SimpleArgumentSyntax simple)
+                var lexicalIx = 0;
+                foreach (var arg in args)
                 {
-                    val = state.AnalysisContext.SemanticModel.GetConstantValue(simple.Expression);
-                }
-                else
-                {
-                    val = new Optional<object>();
-                }
+                    var destIx = methodSymbol?.FindArgumentIndex(lexicalIx, arg) ?? lexicalIx;
 
-                if (val.HasValue)
-                {
-                    vals[destIx] = val.Value?.ToString();
-                }
+                    Optional<object> val;
+                    if (arg is SimpleArgumentSyntax simple)
+                    {
+                        val = state.AnalysisContext.SemanticModel.GetConstantValue(simple.Expression);
+                    }
+                    else
+                    {
+                        val = new Optional<object>();
+                    }
 
-                lexicalIx++;
+                    if (val.HasValue)
+                    {
+                        vals[destIx] = val.Value?.ToString();
+                    }
+
+                    lexicalIx++;
+                }
             }
 
             foreach (var kv in condition)

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -763,12 +763,9 @@ namespace SecurityCodeScan.Analyzers.Taint
 
         private bool BehaviorApplies(IReadOnlyDictionary<object, object> condition, IMethodSymbol methodSymbol, SeparatedSyntaxList<ArgumentSyntax>? args, ExecutionState state)
         {
-            if (condition == null || condition.Count == 0)
+            if (condition == null || methodSymbol == null || condition.Count == 0)
                 return true;
-
-            if (methodSymbol == null)
-                return false;
-
+            
             var ps = methodSymbol.Parameters;
 
             var vals = new string[ps.Length];

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -811,9 +811,10 @@ namespace SecurityCodeScan.Analyzers.Taint
                 lexicalIx++;
             }
 
-            foreach (int ix in condition.Keys)
+            foreach (var kv in condition)
             {
-                var val = (IReadOnlyDictionary<object, object>)condition[ix];
+                var ix = (int)kv.Key;
+                var val = (IReadOnlyDictionary<object, object>)kv.Value;
                 var expectedVal = val["Value"];
                 var codeVal = vals[ix];
 

--- a/SecurityCodeScan/Analyzers/Taint/MethodBehavior.cs
+++ b/SecurityCodeScan/Analyzers/Taint/MethodBehavior.cs
@@ -47,6 +47,7 @@ namespace SecurityCodeScan.Analyzers.Taint
 
     internal class MethodBehavior
     {
+        public IReadOnlyDictionary<object, object>          AppliesUnderCondition { get; }
         public IReadOnlyDictionary<int, InjectableArgument> InjectableArguments { get; }
         public IReadOnlyList<Condition>                     Conditions          { get; }
         public IReadOnlyDictionary<int, PostCondition>      PostConditions      { get; }
@@ -54,15 +55,17 @@ namespace SecurityCodeScan.Analyzers.Taint
 
         private readonly InjectableArgument NotInjectableArgument = new InjectableArgument(0ul, null);
 
-        public MethodBehavior(IReadOnlyList<Condition>                     preConditions,
+        public MethodBehavior(IReadOnlyDictionary<object, object>          appliesUnderCondition,
+                              IReadOnlyList<Condition>                     preConditions,
                               IReadOnlyDictionary<int, PostCondition>      postConditions,
                               IReadOnlyDictionary<int, InjectableArgument> injectableArguments,
                               InjectableArgument                           injectableField)
         {
-            InjectableArguments = injectableArguments ?? EmptyDictionary<int, InjectableArgument>.Value;
-            PostConditions      = postConditions      ?? EmptyDictionary<int, PostCondition>.Value;
-            Conditions          = preConditions       ?? EmptyList<Condition>.Value;
-            InjectableField     = injectableField     ?? NotInjectableArgument;
+            AppliesUnderCondition = appliesUnderCondition ?? EmptyDictionary<object, object>.Value;
+            InjectableArguments = injectableArguments     ?? EmptyDictionary<int, InjectableArgument>.Value;
+            PostConditions      = postConditions          ?? EmptyDictionary<int, PostCondition>.Value;
+            Conditions          = preConditions           ?? EmptyList<Condition>.Value;
+            InjectableField     = injectableField         ?? NotInjectableArgument;
         }
     }
 }

--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -618,7 +618,7 @@ namespace SecurityCodeScan.Config
         {
             foreach (var key in condition.Keys.ToList())
             {
-                if (!(key is int conditionIndex) && !(key is string str && int.TryParse(str, out conditionIndex)))
+                if (!int.TryParse(key.ToString(), out var conditionIndex))
                     throw new Exception("Condition key must be an argument index");
 
                 var val = condition[key];

--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -616,7 +616,7 @@ namespace SecurityCodeScan.Config
 
         private void ValidateCondition(IDictionary<object, object> condition)
         {
-            foreach(var key in condition.Keys.ToList())
+            foreach (var key in condition.Keys.ToList())
             {
                 if (!(key is int conditionIndex) && !(key is string str && int.TryParse(str, out conditionIndex)))
                     throw new Exception("Condition key must be an argument index");
@@ -627,21 +627,39 @@ namespace SecurityCodeScan.Config
                 condition.Remove(key);
                 condition[conditionIndex] = val;
 
-                if(conditionIndex < 0)
+                if (conditionIndex < 0)
                     throw new Exception("Condition key must be an argument index >= 0");
 
-                if(!(val is IReadOnlyDictionary<object, object> valDict))
+                if (!(val is IReadOnlyDictionary<object, object> valDict))
                     throw new Exception("Condition value must be a dictionary");
 
-                if(valDict.Count != 1)
+                if (valDict.Count != 1)
                     throw new Exception("Condition dictionary must have a single value");
 
-                if(!valDict.TryGetValue("Value", out var conditionValue))
+                if (!valDict.TryGetValue("Value", out var conditionValue))
                     throw new Exception("Condition dictionary must contain 'Value'");
 
-                var validConditionValue = conditionValue is string || val is int || val is bool;
-                if (!validConditionValue)
-                    throw new Exception("Condition value must be a string, integer, or boolean");
+                if (!(conditionValue is int) && !(conditionValue is bool))
+                {
+                    var updatedValueDict = new Dictionary<object, object>(1);
+
+                    var asStr = conditionValue?.ToString();
+
+                    if (int.TryParse(asStr, out var asInt))
+                    {
+                        updatedValueDict["Value"] = asInt;
+                    }
+                    else if (bool.TryParse(asStr, out var asBool))
+                    {
+                        updatedValueDict["Value"] = asBool;
+                    }
+                    else
+                    {
+                        throw new Exception("Condition value must be a integer, or boolean");
+                    }
+
+                    condition[conditionIndex] = updatedValueDict;
+                }
             }
         }
 

--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -618,14 +618,22 @@ namespace SecurityCodeScan.Config
         {
             foreach (var key in condition.Keys.ToList())
             {
-                if (!int.TryParse(key.ToString(), out var conditionIndex))
-                    throw new Exception("Condition key must be an argument index");
-
+                int conditionIndex;
                 var val = condition[key];
 
-                // force condition to have a integer typed keys
-                condition.Remove(key);
-                condition[conditionIndex] = val;
+                if (key is int)
+                {
+                    conditionIndex = (int)key;
+                }
+                else
+                {
+                    if (!(key is string keyString) || !int.TryParse(keyString, out conditionIndex))
+                        throw new Exception("Condition key must be an argument index");
+
+                    // force condition to have a integer typed keys
+                    condition.Remove(key);
+                    condition[conditionIndex] = val;
+                }
 
                 if (conditionIndex < 0)
                     throw new Exception("Condition key must be an argument index >= 0");
@@ -643,7 +651,7 @@ namespace SecurityCodeScan.Config
                 {
                     var updatedValueDict = new Dictionary<object, object>(1);
 
-                    var asStr = conditionValue?.ToString();
+                    var asStr = conditionValue as string;
 
                     if (int.TryParse(asStr, out var asInt))
                     {

--- a/SecurityCodeScan/Config/Main.yml
+++ b/SecurityCodeScan/Config/Main.yml
@@ -216,6 +216,7 @@ Behavior:
 #   Name:      (Optional) [Class member name. If not specified applies to all members of the class]
 #   Method: (If it describes a function. Required if child properties are provided, otherwise optional)
 #     ArgTypes:  (Optional) [Function arguments signature. If not specified applies to all overloads]
+#     Condition: (Optional) (The condition that must be met for InjectableArguments to be applied like 'Condition: {1: { Value: False } }')
 #     InjectableArguments: (Optional) [Warning ID, argument index and taint type this possible format:
 #                                      [SCS0018: [0: AbsolutePath, 1: AbsolutePath]] or
 #                                      [SCS0018: [0: AbsolutePath]] or


### PR DESCRIPTION
This is #135, except against master.

I squashed the commits because there was a lot of noise, and cherry-picking all of them was kind of pointless.

As with #136, tests really do not like running on my box.  Makes me want to look into unify master and vs2017 branches, as I suspect the issue is in VS.

---

This is a proposal (and thus a draft PR) to add a `Condition` to behaviors that allows control of whether a behavior's `InjectableArguments` apply, akin to the Condition on attributes from #127 .

Currently, at least as I understand, it is possible to conditionally control what taint is applied to a returned value (either absolutely, or via arguments).  `InjectableArguments` are unconditionally considered.

The motivating use here are RedirectAction returning methods in the Stack Overflow codebase which default to disallowing external domains, but have a parameter that when set allows external targets.  Calls are therefore vulnerable to an open redirect injection only when the parameter is set.  A minimal example of this is in the [included test](https://github.com/kevin-montrose/security-code-scan/blob/7479986823868dcc9c206173ad9629cf1728bf4a/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs#L330).