### PR TITLE
Speed up WeakHashingAnalyzer

### DIFF
--- a/SecurityCodeScan/Analyzers/SecurityAnalysisContext.cs
+++ b/SecurityCodeScan/Analyzers/SecurityAnalysisContext.cs
@@ -42,6 +42,7 @@ namespace SecurityCodeScan.Analyzers
         private void OnCompilationStartAction(CompilationStartAnalysisContext context)
         {
             ProjectConfiguration = new ConfigurationManager().GetProjectConfiguration(context.Options.AdditionalFiles);
+
             foreach (var action in OnCompilationStartActions)
             {
                 action(context, ProjectConfiguration);

--- a/SecurityCodeScan/Analyzers/Utils/AnalyzerUtil.cs
+++ b/SecurityCodeScan/Analyzers/Utils/AnalyzerUtil.cs
@@ -41,6 +41,20 @@ namespace SecurityCodeScan.Analyzers.Utils
             return symbol.IsDerivedFrom(types);
         }
 
+        public static bool IsTypeOrDerivedFrom(this ITypeSymbol symbol, IEnumerable<string> types, out string foundType)
+        {
+            foreach (var type in types)
+            {
+                if (symbol.IsType(type))
+                {
+                    foundType = type;
+                    return true;
+                }
+            }
+
+            return symbol.IsDerivedFrom(types, out foundType);
+        }
+
         public static bool IsDerivedFrom(this ITypeSymbol symbol, string type)
         {
             while (symbol.BaseType != null)
@@ -67,6 +81,26 @@ namespace SecurityCodeScan.Analyzers.Utils
                 }
             }
 
+            return false;
+        }
+
+        public static bool IsDerivedFrom(this ITypeSymbol symbol, IEnumerable<string> types, out string foundType)
+        {
+            while (symbol.BaseType != null)
+            {
+                symbol = symbol.BaseType;
+
+                foreach (var type in types)
+                {
+                    if (symbol.IsType(type))
+                    {
+                        foundType = type;
+                        return true;
+                    }
+                }
+            }
+
+            foundType = null;
             return false;
         }
 


### PR DESCRIPTION
Noticed in some profiling that this was doing double work, visiting everything twice: once for SHA1 and once for MD5.

This does the same logical work, but only walks the gets type names (and walks the type's hierarchy) once.