### PR TITLE
Address false positive Open Redirects for implicit string concats and interpolated strings #152

### DIFF
--- a/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
+++ b/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\SQLite.3.13.0\build\net45\SQLite.props" Condition="Exists('..\packages\SQLite.3.13.0\build\net45\SQLite.props')" />
-  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -225,10 +225,10 @@
       <HintPath>..\packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Data.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.1.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.1.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -430,13 +430,13 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.109.2\build\net451\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.109.2\build\net451\System.Data.SQLite.Core.targets'))" />
     <Error Condition="!Exists('..\packages\SQLite.3.13.0\build\net45\SQLite.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLite.3.13.0\build\net45\SQLite.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\packages\System.Data.SQLite.Core.1.0.109.2\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.109.2\build\net451\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs
@@ -624,14 +624,14 @@ Behavior:
         }
 
         [TestCategory("Safe")]
-        [DataRow("Response.Redirect(\"\"+value)", false, false, new [] { "int", "uint", "short", "ushort", "long", "ulong", "byte", "sbyte", "char", "bool",
-                                                                  "float", "double", "decimal", "System.IntPtr", "System.UIntPtr", "System.Int16",
-                                                                  "System.UInt16", "System.Int32", "System.UInt32", "System.Int64", "System.UInt64",
-                                                                  "System.Single", "System.Double", "System.DateTime", "System.DateTimeOffset", "System.Guid" })]
-        [DataRow("Response.Redirect(\"\"+value)", true,  false, new [] { "int", "uint", "short", "ushort", "long", "ulong", "byte", "sbyte", "char", "bool",
-                                                                  "float", "double", "decimal", "System.IntPtr", "System.UIntPtr", "System.Int16",
-                                                                  "System.UInt16", "System.Int32", "System.UInt32", "System.Int64", "System.UInt64",
-                                                                  "System.Single", "System.Double", "System.DateTime", "System.DateTimeOffset", "System.Guid" })]
+        [DataRow("Response.Redirect(\"\"+value)", false, false, new [] { "System.Byte", "System.SByte", "System.Char", "System.Boolean",
+                                                                         "System.Int16", "System.UInt16", "System.Int32", "System.UInt32",
+                                                                         "System.Int64", "System.UInt64", "System.Single", "System.Double",
+                                                                         "System.Decimal", "System.DateTime" })]
+        [DataRow("Response.Redirect(\"\"+value)", true,  false, new[] { "System.Byte", "System.SByte", "System.Char", "System.Boolean",
+                                                                        "System.Int16", "System.UInt16", "System.Int32", "System.UInt32",
+                                                                        "System.Int64", "System.UInt64", "System.Single", "System.Double",
+                                                                        "System.Decimal", "System.DateTime" })]
         [DataRow("Response.Redirect(\"\"+value)", false, false, new[] { "object" })]
         [DataRow("Response.Redirect(\"\"+value)", true,  true,  new[] { "object" })]
         [DataTestMethod]
@@ -666,10 +666,43 @@ class OpenRedirect
     }}
 }}
 ";
+
+                    var vbTest1 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type})
+        {sink.Replace("+", "&")}
+    End Sub
+End Class
+";
+
+                    var vbTest2 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type})
+        {sink}
+    End Sub
+End Class
+";
+
                     if (warn)
+                    {
                         await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest1, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest2, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                    }
                     else
+                    {
                         await VerifyCSharpDiagnostic(cSharpTest, null, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest1, null, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest2, null, optionsWithProjectConfig).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -711,29 +744,56 @@ class OpenRedirect
     }}
 }}
 ";
+
+                    var vbTest1 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type}, flag As System.Boolean)
+        {sink.Replace("+", "&")}
+    End Sub
+End Class
+";
+
+                    var vbTest2 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type}, flag As System.Boolean)
+        {sink}
+    End Sub
+End Class
+";
+
                     await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                    await VerifyVisualBasicDiagnostic(vbTest1, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                    await VerifyVisualBasicDiagnostic(vbTest2, Expected, optionsWithProjectConfig).ConfigureAwait(false);
                 }
             }
         }
 
         [TestCategory("Safe")]
-        [DataRow("Response.Redirect($\"{value}\")", false, false, new[] { "int", "uint", "short", "ushort", "long", "ulong", "byte", "sbyte", "char", "bool",
-                                                                          "float", "double", "decimal", "System.IntPtr", "System.UIntPtr", "System.Int16",
-                                                                          "System.UInt16", "System.Int32", "System.UInt32", "System.Int64", "System.UInt64",
-                                                                          "System.Single", "System.Double", "System.DateTime", "System.DateTimeOffset", "System.Guid" })]
-        [DataRow("Response.Redirect($\"{value}\")", true,  false, new[] { "int", "uint", "short", "ushort", "long", "ulong", "byte", "sbyte", "char", "bool",
-                                                                          "float", "double", "decimal", "System.IntPtr", "System.UIntPtr", "System.Int16",
-                                                                          "System.UInt16", "System.Int32", "System.UInt32", "System.Int64", "System.UInt64",
-                                                                          "System.Single", "System.Double", "System.DateTime", "System.DateTimeOffset", "System.Guid" })]
+        [DataRow("Response.Redirect($\"{value}\")", false, false, new[] { "System.Byte", "System.SByte", "System.Char", "System.Boolean",
+                                                                          "System.Int16", "System.UInt16", "System.Int32", "System.UInt32",
+                                                                          "System.Int64", "System.UInt64", "System.Single", "System.Double",
+                                                                          "System.Decimal", "System.DateTime" })]
+        [DataRow("Response.Redirect($\"{value}\")", true,  false, new[] { "System.Byte", "System.SByte", "System.Char", "System.Boolean",
+                                                                          "System.Int16", "System.UInt16", "System.Int32", "System.UInt32",
+                                                                          "System.Int64", "System.UInt64", "System.Single", "System.Double",
+                                                                          "System.Decimal", "System.DateTime" })]
 
         [DataRow("Response.Redirect($\"{value}\")", false, false, new[] { "object" })]
         [DataRow("Response.Redirect($\"{value}\")", true,  true, new[] { "object" })]
 
-        [DataRow("Response.Redirect($\"{value:#.0}\")",             false, false, new[] { "float" })] // ensure we're not broken by composite formatting
+        [DataRow("Response.Redirect($\"{value:#.0}\")",             false, false, new[] { "System.Single" })] // ensure we're not broken by composite formatting
         [DataRow("Response.Redirect($\"{value:yyyy'-'MM'-'dd}\")",  false, false, new[] { "System.DateTime" })]
         [DataRow("Response.Redirect($\"{value:O}\")",               false, false, new[] { "System.DateTimeOffset" })]
         [DataRow("Response.Redirect($\"{value:G}\")",               false, false, new[] { "System.Guid" })]
-        [DataRow("Response.Redirect($\"{value:#.0}\")",             true,  false, new[] { "float" })]
+        [DataRow("Response.Redirect($\"{value:#.0}\")",             true,  false, new[] { "System.Single" })]
         [DataRow("Response.Redirect($\"{value:yyyy'-'MM'-'dd}\")",  true,  false, new[] { "System.DateTime" })]
         [DataRow("Response.Redirect($\"{value:O}\")",               true,  false, new[] { "System.DateTimeOffset" })]
         [DataRow("Response.Redirect($\"{value:G}\")",               true,  false, new[] { "System.Guid" })]
@@ -770,10 +830,43 @@ class OpenRedirect
 }}
 ";
 
+
+                    var vbTest1 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type})
+        {sink.Replace("+", "&")}
+    End Sub
+End Class
+";
+
+                    var vbTest2 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type})
+        {sink}
+    End Sub
+End Class
+";
+
                     if (warn)
+                    {
                         await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest1, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest2, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                    }
                     else
+                    {
                         await VerifyCSharpDiagnostic(cSharpTest, null, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest1, null, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest2, null, optionsWithProjectConfig).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -788,8 +881,8 @@ class OpenRedirect
         [DataRow(new[] {"Response.Redirect($\"{flag}{value}\")",
                         "Response.Redirect($\"{flag}{value}\", flag)" }, new object[] { "string" })]
         // concat + interp is still tainted
-        [DataRow(new[] {"Response.Redirect(flag+$\"{value}\")",
-                        "Response.Redirect($\"{value}\"+flag)" }, new object[] { "string" })]
+        [DataRow(new[] {"Response.Redirect(flag + $\"{value}\")",
+                        "Response.Redirect($\"{value}\" + flag)" }, new object[] { "string" })]
         [DataTestMethod]
         public async Task OpenRedirectInterpolatedStringDetect(string[] sinks, params string[] types)
         {
@@ -823,7 +916,33 @@ class OpenRedirect
 }}
 ";
 
+                        var vbTest1 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type}, flag As System.Boolean)
+        {sink.Replace("+", "&")}
+    End Sub
+End Class
+";
+
+                        var vbTest2 = $@"
+Imports {@namespace}
+
+Class OpenRedirect
+    Public Shared Response As HttpResponse = Nothing
+
+    Public Sub Run(value As {type}, flag As System.Boolean)
+        {sink}
+    End Sub
+End Class
+";
+
                         await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest1, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+                        await VerifyVisualBasicDiagnostic(vbTest2, Expected, optionsWithProjectConfig).ConfigureAwait(false);
                     }
                 }
             }

--- a/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/OpenRedirectAnalyzerTest.cs
@@ -707,5 +707,106 @@ TaintEntryPoints:
             var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
             await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
         }
+
+        [TestCategory("Safe")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "int")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "short")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "long")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "uint")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\")", "ushort")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "ulong")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "byte")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "sbyte")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "char")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "System.IntPtr")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\")", "System.UIntPtr")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "bool")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "float")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "double")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\")", "decimal")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "System.Int16")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\")", "System.Single")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "System.UInt64")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "System.DateTime")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "System.DateTimeOffset")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "System.Guid")]
+        [DataRow("System.Web", "Response.Redirect($\"{value:#.0}\")", "float")] // ensure we're not broken by composite formatting
+        [DataRow("System.Web", "Response.Redirect($\"{value:yyyy'-'MM'-'dd}\")", "System.DateTime")]
+        [DataRow("System.Web", "Response.Redirect($\"{value:O}\")", "System.DateTimeOffset")]
+        [DataRow("System.Web", "Response.Redirect($\"{value:G}\")", "System.Guid")]
+        [DataTestMethod]
+        public async Task OpenRedirectInterpolatedStringSafe(string @namespace, string sink, string type)
+        {
+            var cSharpTest = $@"
+using {@namespace};
+
+class OpenRedirect
+{{
+    public static HttpResponse Response = null;
+
+    public void Run({type} value)
+    {{
+        {sink};
+    }}
+}}
+";
+
+            var testConfig = @"
+TaintEntryPoints:
+  AAA:
+    ClassName: OpenRedirect
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest, null, optionsWithProjectConfig).ConfigureAwait(false);
+        }
+
+        [TestCategory("Detect")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "string")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\", flag)", "string")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\")", "string")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\", flag)", "string")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\")", "object")]
+        [DataRow("System.Web", "Response.Redirect($\"{value}\", flag)", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\")", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\", flag)", "object")]
+        [DataRow("System.Web", "Response.Redirect($\"{value:G}\")", "object")] // we're still tainted if we use a format string
+        [DataRow("System.Web", "Response.Redirect($\"{value:G}\", flag)", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value:G}\")", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value:G}\", flag)", "object")]
+        [DataRow("System.Web", "Response.Redirect($\"{flag}{value}\")", "object")] // {flag} is safe, ensure we're still tainted
+        [DataRow("System.Web", "Response.Redirect($\"{flag}{value}\", flag)", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{flag}{value}\")", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{flag}{value}\", flag)", "object")]
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect(flag+$\"{value}\")", "string")] // concat + interp is still tainted
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\"+flag)", "string")] 
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect(flag+$\"{value}\")", "object")] 
+        [DataRow("Microsoft.AspNetCore.Http", "Response.Redirect($\"{value}\"+flag)", "object")] 
+        [DataTestMethod]
+        public async Task OpenRedirectInterpolatedStringDetect(string @namespace, string sink, string type)
+        {
+            var cSharpTest = $@"
+using {@namespace};
+
+class OpenRedirect
+{{
+    public static HttpResponse Response = null;
+
+    public void Run({type} value, bool flag)
+    {{
+        {sink};
+    }}
+}}
+";
+
+            var testConfig = @"
+TaintEntryPoints:
+  AAA:
+    ClassName: OpenRedirect
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+        }
     }
 }

--- a/SecurityCodeScan.Test/packages.config
+++ b/SecurityCodeScan.Test/packages.config
@@ -67,8 +67,8 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Microsoft.Web.Xdt" version="2.1.2" targetFramework="net452" />
   <package id="Moq" version="4.5.16" targetFramework="net452" />
-  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="2.1.0" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="2.1.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="net452" />

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -1307,12 +1307,13 @@ namespace SecurityCodeScan.Analyzers.Taint
 
             // Detect implicit conversions to string through concatenation
             // with the binary Add operator.
-            if (expression.Kind() == SyntaxKind.AddExpression && IsStringType(state, expression))
+            if (expression.Kind() == SyntaxKind.AddExpression &&
+                ReferenceEquals(state.AnalysisContext.SemanticModel.GetTypeInfo(expression).ConvertedType, state.StringType))
             {
                 // We only do this check if one side is a string
                 // and the other side is not.
-                bool leftIsString = IsStringType(state, leftExpression);
-                bool rightIsString = IsStringType(state, rightExpression);
+                bool leftIsString = ReferenceEquals(state.AnalysisContext.SemanticModel.GetTypeInfo(leftExpression).Type, state.StringType);
+                bool rightIsString = ReferenceEquals(state.AnalysisContext.SemanticModel.GetTypeInfo(rightExpression).Type, state.StringType);
                 if (leftIsString != rightIsString)
                 {
                     if (!leftIsString)
@@ -1334,19 +1335,6 @@ namespace SecurityCodeScan.Analyzers.Taint
             result.MergeTaint(right.Taint);
 
             return result;
-        }
-
-        /// <summary>
-        /// Determines if an expression is ultimately a string type.
-        /// </summary>
-        /// <param name="state">The current execution state.</param>
-        /// <param name="expression">The expression being evaluated.</param>
-        /// <returns><see langword="true"/> if <paramref name="expression"/> is considered
-        /// a string, otherwise <see langword="false"/>.</returns>
-        private static bool IsStringType(ExecutionState state, ExpressionSyntax expression)
-        {
-            ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).ConvertedType;
-            return ReferenceEquals(type, state.StringType);
         }
 
         /// <summary>

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -1359,26 +1359,8 @@ namespace SecurityCodeScan.Analyzers.Taint
         private bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
         {
             ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
-            return (!ProjectConfiguration.AuditMode && ReferenceEquals(type, state.ObjectType))
-                || ReferenceEquals(type, state.BooleanType)
-                || ReferenceEquals(type, state.CharType)
-                || ReferenceEquals(type, state.ByteType)
-                || ReferenceEquals(type, state.SByteType)
-                || ReferenceEquals(type, state.Int16Type)
-                || ReferenceEquals(type, state.UInt16Type)
-                || ReferenceEquals(type, state.Int32Type)
-                || ReferenceEquals(type, state.UInt32Type)
-                || ReferenceEquals(type, state.Int64Type)
-                || ReferenceEquals(type, state.UInt64Type)
-                || ReferenceEquals(type, state.IntPtrType)
-                || ReferenceEquals(type, state.UIntPtrType)
-                || ReferenceEquals(type, state.SingleType)
-                || ReferenceEquals(type, state.DoubleType)
-                || ReferenceEquals(type, state.DecimalType)
-                || ReferenceEquals(type, state.EnumType)
-                || ReferenceEquals(type, state.DateTimeType)
-                || ReferenceEquals(type, state.DateTimeOffsetType)
-                || ReferenceEquals(type, state.GuidType);
+            return !ReferenceEquals(type, state.StringType) &&
+                   (!ProjectConfiguration.AuditMode || !ReferenceEquals(type, state.ObjectType));
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -572,6 +572,8 @@ namespace SecurityCodeScan.Analyzers.Taint
                     return VisitExpression(awaitSyntax.Expression, state);
                 case ThisExpressionSyntax thisExpressionSyntax:
                     return new VariableState(thisExpressionSyntax, VariableTaint.Unknown);
+                case PredefinedTypeSyntax predefinedTypeSyntax:
+                    return new VariableState(predefinedTypeSyntax, VariableTaint.Unknown);
                 case AnonymousObjectCreationExpressionSyntax anonymousObjectCreationExpressionSyntax:
                     {
                         var finalState = new VariableState(anonymousObjectCreationExpressionSyntax, VariableTaint.Unset);
@@ -1347,8 +1349,7 @@ namespace SecurityCodeScan.Analyzers.Taint
         private bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
         {
             ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
-            return !ReferenceEquals(type, state.StringType) &&
-                   (!ProjectConfiguration.AuditMode || !ReferenceEquals(type, state.ObjectType));
+            return !ReferenceEquals(type, state.StringType) && !ReferenceEquals(type, state.ObjectType);
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -1358,26 +1358,26 @@ namespace SecurityCodeScan.Analyzers.Taint
         /// safe when converted to its string representation, otherwise <see langword="false"/>.</returns>
         private static bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
         {
-            ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).ConvertedType;
-            return Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Boolean))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Char))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Byte))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_SByte))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Int16))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_UInt16))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Int32))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_UInt32))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Int64))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_UInt64))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_IntPtr))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_UIntPtr))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Single))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Double))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Decimal))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_Enum))
-                || Equals(type, state.AnalysisContext.Compilation.GetSpecialType(SpecialType.System_DateTime))
-                || Equals(type, state.AnalysisContext.Compilation.GetTypeByMetadataName("System.Guid"))
-                || Equals(type, state.AnalysisContext.Compilation.GetTypeByMetadataName("System.DateTimeOffset"));
+            ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
+            return Equals(type, state.BooleanType)
+                || Equals(type, state.CharType)
+                || Equals(type, state.ByteType)
+                || Equals(type, state.SByteType)
+                || Equals(type, state.Int16Type)
+                || Equals(type, state.UInt16Type)
+                || Equals(type, state.Int32Type)
+                || Equals(type, state.UInt32Type)
+                || Equals(type, state.Int64Type)
+                || Equals(type, state.UInt64Type)
+                || Equals(type, state.IntPtrType)
+                || Equals(type, state.UIntPtrType)
+                || Equals(type, state.SingleType)
+                || Equals(type, state.DoubleType)
+                || Equals(type, state.DecimalType)
+                || Equals(type, state.EnumType)
+                || Equals(type, state.DateTimeType)
+                || Equals(type, state.DateTimeOffsetType)
+                || Equals(type, state.GuidType);
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -1356,10 +1356,11 @@ namespace SecurityCodeScan.Analyzers.Taint
         /// <param name="expression">The expression being evaluated.</param>
         /// <returns><see langword="true"/> if <paramref name="expression"/> is considered
         /// safe when converted to its string representation, otherwise <see langword="false"/>.</returns>
-        private static bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
+        private bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
         {
             ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
-            return ReferenceEquals(type, state.BooleanType)
+            return (!ProjectConfiguration.AuditMode && ReferenceEquals(type, state.ObjectType))
+                || ReferenceEquals(type, state.BooleanType)
                 || ReferenceEquals(type, state.CharType)
                 || ReferenceEquals(type, state.ByteType)
                 || ReferenceEquals(type, state.SByteType)

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -1346,7 +1346,7 @@ namespace SecurityCodeScan.Analyzers.Taint
         private static bool IsStringType(ExecutionState state, ExpressionSyntax expression)
         {
             ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).ConvertedType;
-            return Equals(type, state.StringType);
+            return ReferenceEquals(type, state.StringType);
         }
 
         /// <summary>
@@ -1359,25 +1359,25 @@ namespace SecurityCodeScan.Analyzers.Taint
         private static bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
         {
             ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
-            return Equals(type, state.BooleanType)
-                || Equals(type, state.CharType)
-                || Equals(type, state.ByteType)
-                || Equals(type, state.SByteType)
-                || Equals(type, state.Int16Type)
-                || Equals(type, state.UInt16Type)
-                || Equals(type, state.Int32Type)
-                || Equals(type, state.UInt32Type)
-                || Equals(type, state.Int64Type)
-                || Equals(type, state.UInt64Type)
-                || Equals(type, state.IntPtrType)
-                || Equals(type, state.UIntPtrType)
-                || Equals(type, state.SingleType)
-                || Equals(type, state.DoubleType)
-                || Equals(type, state.DecimalType)
-                || Equals(type, state.EnumType)
-                || Equals(type, state.DateTimeType)
-                || Equals(type, state.DateTimeOffsetType)
-                || Equals(type, state.GuidType);
+            return ReferenceEquals(type, state.BooleanType)
+                || ReferenceEquals(type, state.CharType)
+                || ReferenceEquals(type, state.ByteType)
+                || ReferenceEquals(type, state.SByteType)
+                || ReferenceEquals(type, state.Int16Type)
+                || ReferenceEquals(type, state.UInt16Type)
+                || ReferenceEquals(type, state.Int32Type)
+                || ReferenceEquals(type, state.UInt32Type)
+                || ReferenceEquals(type, state.Int64Type)
+                || ReferenceEquals(type, state.UInt64Type)
+                || ReferenceEquals(type, state.IntPtrType)
+                || ReferenceEquals(type, state.UIntPtrType)
+                || ReferenceEquals(type, state.SingleType)
+                || ReferenceEquals(type, state.DoubleType)
+                || ReferenceEquals(type, state.DecimalType)
+                || ReferenceEquals(type, state.EnumType)
+                || ReferenceEquals(type, state.DateTimeType)
+                || ReferenceEquals(type, state.DateTimeOffsetType)
+                || ReferenceEquals(type, state.GuidType);
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -1352,8 +1352,7 @@ namespace SecurityCodeScan.Analyzers.Taint
         private bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
         {
             ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
-            return !ReferenceEquals(type, state.StringType) &&
-                   (!ProjectConfiguration.AuditMode || !ReferenceEquals(type, state.ObjectType));
+            return !ReferenceEquals(type, state.StringType) && !ReferenceEquals(type, state.ObjectType);
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/VbCodeEvaluation.cs
@@ -634,7 +634,7 @@ namespace SecurityCodeScan.Analyzers.Taint
                     continue;
 
                 var expressionState = VisitExpression(interpolation.Expression, state);
-                varState.MergeTaint(expressionState.Taint);
+                varState.MergeTaint(IsSafeTypeAsString(state, interpolation.Expression) ? VariableTaint.Safe : expressionState.Taint);
             }
 
             return varState;
@@ -1085,14 +1085,42 @@ namespace SecurityCodeScan.Analyzers.Taint
         /// <returns></returns>
         private VariableState VisitBinaryExpression(ExpressionSyntax expression,
                                                     ExpressionSyntax leftExpression,
-                                                    ExpressionSyntax rightExrpession,
+                                                    ExpressionSyntax rightExpression,
                                                     ExecutionState state)
         {
             var result = new VariableState(expression, VariableTaint.Unset);
-            var left   = VisitExpression(leftExpression, state);
+            var left  = VisitExpression(leftExpression, state);
+            var right = VisitExpression(rightExpression, state);
+
+            // Detect implicit conversions to string through concatenation
+            // with the binary Add operator.
+            if ((expression.Kind() == SyntaxKind.ConcatenateExpression || expression.Kind() == SyntaxKind.AddExpression) &&
+                ReferenceEquals(state.AnalysisContext.SemanticModel.GetTypeInfo(expression).ConvertedType, state.StringType))
+            {
+                // We only do this check if one side is a string
+                // and the other side is not.
+                bool leftIsString = ReferenceEquals(state.AnalysisContext.SemanticModel.GetTypeInfo(leftExpression).Type, state.StringType);
+                bool rightIsString = ReferenceEquals(state.AnalysisContext.SemanticModel.GetTypeInfo(rightExpression).Type, state.StringType);
+                if (leftIsString != rightIsString)
+                {
+                    if (!leftIsString)
+                    {
+                        result.MergeTaint(IsSafeTypeAsString(state, leftExpression) ? VariableTaint.Safe : left.Taint);
+                        result.MergeTaint(right.Taint);
+                    }
+                    else
+                    {
+                        result.MergeTaint(left.Taint);
+                        result.MergeTaint(IsSafeTypeAsString(state, rightExpression) ? VariableTaint.Safe : right.Taint);
+                    }
+
+                    return result;
+                }
+            }
+
             result.MergeTaint(left.Taint);
-            var right = VisitExpression(rightExrpession, state);
             result.MergeTaint(right.Taint);
+
             return result;
         }
 
@@ -1312,6 +1340,20 @@ namespace SecurityCodeScan.Analyzers.Taint
         private string ResolveIdentifier(SyntaxToken syntaxToken)
         {
             return syntaxToken.Text;
+        }
+
+        /// <summary>
+        /// Determines if an expression is safe if converted to a string.
+        /// </summary>
+        /// <param name="state">The current execution state.</param>
+        /// <param name="expression">The expression being evaluated.</param>
+        /// <returns><see langword="true"/> if <paramref name="expression"/> is considered
+        /// safe when converted to its string representation, otherwise <see langword="false"/>.</returns>
+        private bool IsSafeTypeAsString(ExecutionState state, ExpressionSyntax expression)
+        {
+            ITypeSymbol type = state.AnalysisContext.SemanticModel.GetTypeInfo(expression).Type;
+            return !ReferenceEquals(type, state.StringType) &&
+                   (!ProjectConfiguration.AuditMode || !ReferenceEquals(type, state.ObjectType));
         }
     }
 }

--- a/SecurityCodeScan/Analyzers/Taint/ExecutionState.cs
+++ b/SecurityCodeScan/Analyzers/Taint/ExecutionState.cs
@@ -21,6 +21,44 @@ namespace SecurityCodeScan.Analyzers.Taint
 
         private Lazy<INamedTypeSymbol>                     _StringType;
         public INamedTypeSymbol                            StringType            => _StringType.Value;
+        private Lazy<INamedTypeSymbol>                     _CharType;
+        public INamedTypeSymbol                            CharType              => _CharType.Value;
+        private Lazy<INamedTypeSymbol>                     _BooleanType;
+        public INamedTypeSymbol                            BooleanType           => _BooleanType.Value;
+        private Lazy<INamedTypeSymbol>                     _ByteType;
+        public INamedTypeSymbol                            ByteType              => _ByteType.Value;
+        private Lazy<INamedTypeSymbol>                     _SByteType;
+        public INamedTypeSymbol                            SByteType             => _SByteType.Value;
+        private Lazy<INamedTypeSymbol>                     _Int16Type;
+        public INamedTypeSymbol                            Int16Type             => _Int16Type.Value;
+        private Lazy<INamedTypeSymbol>                     _UInt16Type;
+        public INamedTypeSymbol                            UInt16Type            => _UInt16Type.Value;
+        private Lazy<INamedTypeSymbol>                     _Int32Type;
+        public INamedTypeSymbol                            Int32Type             => _Int32Type.Value;
+        private Lazy<INamedTypeSymbol>                     _UInt32Type;
+        public INamedTypeSymbol                            UInt32Type            => _UInt32Type.Value;
+        private Lazy<INamedTypeSymbol>                     _Int64Type;
+        public INamedTypeSymbol                            Int64Type             => _Int64Type.Value;
+        private Lazy<INamedTypeSymbol>                     _UInt64Type;
+        public INamedTypeSymbol                            UInt64Type            => _UInt64Type.Value;
+        private Lazy<INamedTypeSymbol>                     _IntPtrType;
+        public INamedTypeSymbol                            IntPtrType            => _IntPtrType.Value;
+        private Lazy<INamedTypeSymbol>                     _UIntPtrType;
+        public INamedTypeSymbol                            UIntPtrType           => _UIntPtrType.Value;
+        private Lazy<INamedTypeSymbol>                     _SingleType;
+        public INamedTypeSymbol                            SingleType            => _SingleType.Value;
+        private Lazy<INamedTypeSymbol>                     _DoubleType;
+        public INamedTypeSymbol                            DoubleType            => _DoubleType.Value;
+        private Lazy<INamedTypeSymbol>                     _DecimalType;
+        public INamedTypeSymbol                            DecimalType           => _DecimalType.Value;
+        private Lazy<INamedTypeSymbol>                     _EnumType;
+        public INamedTypeSymbol                            EnumType              => _EnumType.Value;
+        private Lazy<INamedTypeSymbol>                     _DateTimeType;
+        public INamedTypeSymbol                            DateTimeType          => _DateTimeType.Value;
+        private Lazy<INamedTypeSymbol>                     _DateTimeOffsetType;
+        public INamedTypeSymbol                            DateTimeOffsetType    => _DateTimeOffsetType.Value;
+        private Lazy<INamedTypeSymbol>                     _GuidType;
+        public INamedTypeSymbol                            GuidType              => _GuidType.Value;
 
         /// <summary>
         /// Initialize the state with no variable recorded yet.
@@ -30,7 +68,26 @@ namespace SecurityCodeScan.Analyzers.Taint
         {
             AnalysisContext = ctx;
             Variables = new Dictionary<string, VariableState>();
-            _StringType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.String"));
+            _StringType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_String));
+            _CharType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Char));
+            _BooleanType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Boolean));
+            _ByteType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Byte));
+            _SByteType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_SByte));
+            _Int16Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int16));
+            _UInt16Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt16));
+            _Int32Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int32));
+            _UInt32Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt32));
+            _Int64Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int64));
+            _UInt64Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt64));
+            _IntPtrType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_IntPtr));
+            _UIntPtrType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UIntPtr));
+            _SingleType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Single));
+            _DoubleType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Double));
+            _DecimalType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Decimal));
+            _EnumType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Enum));
+            _DateTimeType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_DateTime));
+            _DateTimeOffsetType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.DateTimeOffset"));
+            _GuidType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.Guid"));
         }
 
         public ExecutionState(ExecutionState other)

--- a/SecurityCodeScan/Analyzers/Taint/ExecutionState.cs
+++ b/SecurityCodeScan/Analyzers/Taint/ExecutionState.cs
@@ -19,46 +19,65 @@ namespace SecurityCodeScan.Analyzers.Taint
         public  IReadOnlyDictionary<string, VariableState> VariableStates        => Variables;
         private Dictionary<string, VariableState>          Variables             { get; set; }
 
-        private Lazy<INamedTypeSymbol>                     _StringType;
-        public INamedTypeSymbol                            StringType            => _StringType.Value;
-        private Lazy<INamedTypeSymbol>                     _CharType;
-        public INamedTypeSymbol                            CharType              => _CharType.Value;
-        private Lazy<INamedTypeSymbol>                     _BooleanType;
-        public INamedTypeSymbol                            BooleanType           => _BooleanType.Value;
-        private Lazy<INamedTypeSymbol>                     _ByteType;
-        public INamedTypeSymbol                            ByteType              => _ByteType.Value;
-        private Lazy<INamedTypeSymbol>                     _SByteType;
-        public INamedTypeSymbol                            SByteType             => _SByteType.Value;
-        private Lazy<INamedTypeSymbol>                     _Int16Type;
-        public INamedTypeSymbol                            Int16Type             => _Int16Type.Value;
-        private Lazy<INamedTypeSymbol>                     _UInt16Type;
-        public INamedTypeSymbol                            UInt16Type            => _UInt16Type.Value;
-        private Lazy<INamedTypeSymbol>                     _Int32Type;
-        public INamedTypeSymbol                            Int32Type             => _Int32Type.Value;
-        private Lazy<INamedTypeSymbol>                     _UInt32Type;
-        public INamedTypeSymbol                            UInt32Type            => _UInt32Type.Value;
-        private Lazy<INamedTypeSymbol>                     _Int64Type;
-        public INamedTypeSymbol                            Int64Type             => _Int64Type.Value;
-        private Lazy<INamedTypeSymbol>                     _UInt64Type;
-        public INamedTypeSymbol                            UInt64Type            => _UInt64Type.Value;
-        private Lazy<INamedTypeSymbol>                     _IntPtrType;
-        public INamedTypeSymbol                            IntPtrType            => _IntPtrType.Value;
-        private Lazy<INamedTypeSymbol>                     _UIntPtrType;
-        public INamedTypeSymbol                            UIntPtrType           => _UIntPtrType.Value;
-        private Lazy<INamedTypeSymbol>                     _SingleType;
-        public INamedTypeSymbol                            SingleType            => _SingleType.Value;
-        private Lazy<INamedTypeSymbol>                     _DoubleType;
-        public INamedTypeSymbol                            DoubleType            => _DoubleType.Value;
-        private Lazy<INamedTypeSymbol>                     _DecimalType;
-        public INamedTypeSymbol                            DecimalType           => _DecimalType.Value;
-        private Lazy<INamedTypeSymbol>                     _EnumType;
-        public INamedTypeSymbol                            EnumType              => _EnumType.Value;
-        private Lazy<INamedTypeSymbol>                     _DateTimeType;
-        public INamedTypeSymbol                            DateTimeType          => _DateTimeType.Value;
-        private Lazy<INamedTypeSymbol>                     _DateTimeOffsetType;
-        public INamedTypeSymbol                            DateTimeOffsetType    => _DateTimeOffsetType.Value;
-        private Lazy<INamedTypeSymbol>                     _GuidType;
-        public INamedTypeSymbol                            GuidType              => _GuidType.Value;
+        private Lazy<INamedTypeSymbol>                     StringTypeCached;
+        public INamedTypeSymbol                            StringType            => StringTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     CharTypeCached;
+        public INamedTypeSymbol                            CharType              => CharTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     BooleanTypeCached;
+        public INamedTypeSymbol                            BooleanType           => BooleanTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     ByteTypeCached;
+        public INamedTypeSymbol                            ByteType              => ByteTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     SByteTypeCached;
+        public INamedTypeSymbol                            SByteType             => SByteTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     Int16TypeCached;
+        public INamedTypeSymbol                            Int16Type             => Int16TypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     UInt16TypeCached;
+        public INamedTypeSymbol                            UInt16Type            => UInt16TypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     Int32TypeCached;
+        public INamedTypeSymbol                            Int32Type             => Int32TypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     UInt32TypeCached;
+        public INamedTypeSymbol                            UInt32Type            => UInt32TypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     Int64TypeCached;
+        public INamedTypeSymbol                            Int64Type             => Int64TypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     UInt64TypeCached;
+        public INamedTypeSymbol                            UInt64Type            => UInt64TypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     IntPtrTypeCached;
+        public INamedTypeSymbol                            IntPtrType            => IntPtrTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     UIntPtrTypeCached;
+        public INamedTypeSymbol                            UIntPtrType           => UIntPtrTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     SingleTypeCached;
+        public INamedTypeSymbol                            SingleType            => SingleTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     DoubleTypeCached;
+        public INamedTypeSymbol                            DoubleType            => DoubleTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     DecimalTypeCached;
+        public INamedTypeSymbol                            DecimalType           => DecimalTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     EnumTypeCached;
+        public INamedTypeSymbol                            EnumType              => EnumTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     DateTimeTypeCached;
+        public INamedTypeSymbol                            DateTimeType          => DateTimeTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     DateTimeOffsetTypeCached;
+        public INamedTypeSymbol                            DateTimeOffsetType    => DateTimeOffsetTypeCached.Value;
+
+        private Lazy<INamedTypeSymbol>                     GuidTypeCached;
+        public INamedTypeSymbol                            GuidType              => GuidTypeCached.Value;
 
         /// <summary>
         /// Initialize the state with no variable recorded yet.
@@ -68,33 +87,52 @@ namespace SecurityCodeScan.Analyzers.Taint
         {
             AnalysisContext = ctx;
             Variables = new Dictionary<string, VariableState>();
-            _StringType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_String));
-            _CharType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Char));
-            _BooleanType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Boolean));
-            _ByteType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Byte));
-            _SByteType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_SByte));
-            _Int16Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int16));
-            _UInt16Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt16));
-            _Int32Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int32));
-            _UInt32Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt32));
-            _Int64Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int64));
-            _UInt64Type = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt64));
-            _IntPtrType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_IntPtr));
-            _UIntPtrType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UIntPtr));
-            _SingleType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Single));
-            _DoubleType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Double));
-            _DecimalType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Decimal));
-            _EnumType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Enum));
-            _DateTimeType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_DateTime));
-            _DateTimeOffsetType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.DateTimeOffset"));
-            _GuidType = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.Guid"));
+            StringTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_String));
+            CharTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Char));
+            BooleanTypeCached           = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Boolean));
+            ByteTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Byte));
+            SByteTypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_SByte));
+            Int16TypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int16));
+            UInt16TypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt16));
+            Int32TypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int32));
+            UInt32TypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt32));
+            Int64TypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int64));
+            UInt64TypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt64));
+            IntPtrTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_IntPtr));
+            UIntPtrTypeCached           = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UIntPtr));
+            SingleTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Single));
+            DoubleTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Double));
+            DecimalTypeCached           = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Decimal));
+            EnumTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Enum));
+            DateTimeTypeCached          = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_DateTime));
+            DateTimeOffsetTypeCached    = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.DateTimeOffset"));
+            GuidTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.Guid"));
         }
 
         public ExecutionState(ExecutionState other)
         {
             AnalysisContext = other.AnalysisContext;
             Variables       = new Dictionary<string, VariableState>(other.VariableStates.Count);
-            _StringType     = other._StringType;
+            StringTypeCached            = other.StringTypeCached;
+            CharTypeCached              = other.CharTypeCached;
+            BooleanTypeCached           = other.BooleanTypeCached;
+            ByteTypeCached              = other.ByteTypeCached;
+            SByteTypeCached             = other.SByteTypeCached;
+            Int16TypeCached             = other.Int16TypeCached;
+            UInt16TypeCached            = other.UInt16TypeCached;
+            Int32TypeCached             = other.Int32TypeCached;
+            UInt32TypeCached            = other.UInt32TypeCached;
+            Int64TypeCached             = other.Int64TypeCached;
+            UInt64TypeCached            = other.UInt64TypeCached;
+            IntPtrTypeCached            = other.IntPtrTypeCached;
+            UIntPtrTypeCached           = other.UIntPtrTypeCached;
+            SingleTypeCached            = other.SingleTypeCached;
+            DoubleTypeCached            = other.DoubleTypeCached;
+            DecimalTypeCached           = other.DecimalTypeCached;
+            EnumTypeCached              = other.EnumTypeCached;
+            DateTimeTypeCached          = other.DateTimeTypeCached;
+            DateTimeOffsetTypeCached    = other.DateTimeOffsetTypeCached;
+            GuidTypeCached              = other.GuidTypeCached;
 
             var otherVariableStateToNew = new Dictionary<VariableState, VariableState>();
             foreach (var otherVariablePair in other.VariableStates)
@@ -125,16 +163,63 @@ namespace SecurityCodeScan.Analyzers.Taint
             }
         }
 
-        public void Replace(ExecutionState state)
+        private void MergeCachedTypes(ExecutionState state)
         {
-            AnalysisContext = state.AnalysisContext;
-            Variables       = state.Variables;
-            if (!_StringType.IsValueCreated && state._StringType.IsValueCreated) // prone for race conditions, but small optimization
-                _StringType = state._StringType;
+            // prone for race conditions, but small optimization
+            if (!StringTypeCached.IsValueCreated && state.StringTypeCached.IsValueCreated)
+                StringTypeCached = state.StringTypeCached;
+            if (!CharTypeCached.IsValueCreated && state.CharTypeCached.IsValueCreated)
+                CharTypeCached = state.CharTypeCached;
+            if (!BooleanTypeCached.IsValueCreated && state.BooleanTypeCached.IsValueCreated)
+                BooleanTypeCached = state.BooleanTypeCached;
+            if (!ByteTypeCached.IsValueCreated && state.ByteTypeCached.IsValueCreated)
+                ByteTypeCached = state.ByteTypeCached;
+            if (!SByteTypeCached.IsValueCreated && state.SByteTypeCached.IsValueCreated)
+                SByteTypeCached = state.SByteTypeCached;
+            if (!Int16TypeCached.IsValueCreated && state.Int16TypeCached.IsValueCreated)
+                Int16TypeCached = state.Int16TypeCached;
+            if (!UInt16TypeCached.IsValueCreated && state.UInt16TypeCached.IsValueCreated)
+                UInt16TypeCached = state.UInt16TypeCached;
+            if (!Int32TypeCached.IsValueCreated && state.Int32TypeCached.IsValueCreated)
+                Int32TypeCached = state.Int32TypeCached;
+            if (!UInt32TypeCached.IsValueCreated && state.UInt32TypeCached.IsValueCreated)
+                UInt32TypeCached = state.UInt32TypeCached;
+            if (!Int64TypeCached.IsValueCreated && state.Int64TypeCached.IsValueCreated)
+                Int64TypeCached = state.Int64TypeCached;
+            if (!UInt64TypeCached.IsValueCreated && state.UInt64TypeCached.IsValueCreated)
+                UInt64TypeCached = state.UInt64TypeCached;
+            if (!IntPtrTypeCached.IsValueCreated && state.IntPtrTypeCached.IsValueCreated)
+                IntPtrTypeCached = state.IntPtrTypeCached;
+            if (!UIntPtrTypeCached.IsValueCreated && state.UIntPtrTypeCached.IsValueCreated)
+                UIntPtrTypeCached = state.UIntPtrTypeCached;
+            if (!SingleTypeCached.IsValueCreated && state.SingleTypeCached.IsValueCreated)
+                SingleTypeCached = state.SingleTypeCached;
+            if (!DoubleTypeCached.IsValueCreated && state.DoubleTypeCached.IsValueCreated)
+                DoubleTypeCached = state.DoubleTypeCached;
+            if (!DecimalTypeCached.IsValueCreated && state.DecimalTypeCached.IsValueCreated)
+                DecimalTypeCached = state.DecimalTypeCached;
+            if (!EnumTypeCached.IsValueCreated && state.EnumTypeCached.IsValueCreated)
+                EnumTypeCached = state.EnumTypeCached;
+            if (!DateTimeTypeCached.IsValueCreated && state.DateTimeTypeCached.IsValueCreated)
+                DateTimeTypeCached = state.DateTimeTypeCached;
+            if (!DateTimeOffsetTypeCached.IsValueCreated && state.DateTimeOffsetTypeCached.IsValueCreated)
+                DateTimeOffsetTypeCached = state.DateTimeOffsetTypeCached;
+            if (!GuidTypeCached.IsValueCreated && state.GuidTypeCached.IsValueCreated)
+                GuidTypeCached = state.GuidTypeCached;
+        }
+
+        public void Replace(ExecutionState other)
+        {
+            AnalysisContext = other.AnalysisContext;
+            Variables       = other.Variables;
+
+            MergeCachedTypes(other);
         }
 
         public void Merge(ExecutionState other)
         {
+            MergeCachedTypes(other);
+
             var queue = new Queue<KeyValuePair<VariableState, VariableState>>();
             var otherToSelf = new Dictionary<VariableState, VariableState>();
 

--- a/SecurityCodeScan/Analyzers/Taint/ExecutionState.cs
+++ b/SecurityCodeScan/Analyzers/Taint/ExecutionState.cs
@@ -25,63 +25,6 @@ namespace SecurityCodeScan.Analyzers.Taint
         private Lazy<INamedTypeSymbol>                     StringTypeCached;
         public INamedTypeSymbol                            StringType            => StringTypeCached.Value;
 
-        private Lazy<INamedTypeSymbol>                     CharTypeCached;
-        public INamedTypeSymbol                            CharType              => CharTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     BooleanTypeCached;
-        public INamedTypeSymbol                            BooleanType           => BooleanTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     ByteTypeCached;
-        public INamedTypeSymbol                            ByteType              => ByteTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     SByteTypeCached;
-        public INamedTypeSymbol                            SByteType             => SByteTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     Int16TypeCached;
-        public INamedTypeSymbol                            Int16Type             => Int16TypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     UInt16TypeCached;
-        public INamedTypeSymbol                            UInt16Type            => UInt16TypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     Int32TypeCached;
-        public INamedTypeSymbol                            Int32Type             => Int32TypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     UInt32TypeCached;
-        public INamedTypeSymbol                            UInt32Type            => UInt32TypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     Int64TypeCached;
-        public INamedTypeSymbol                            Int64Type             => Int64TypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     UInt64TypeCached;
-        public INamedTypeSymbol                            UInt64Type            => UInt64TypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     IntPtrTypeCached;
-        public INamedTypeSymbol                            IntPtrType            => IntPtrTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     UIntPtrTypeCached;
-        public INamedTypeSymbol                            UIntPtrType           => UIntPtrTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     SingleTypeCached;
-        public INamedTypeSymbol                            SingleType            => SingleTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     DoubleTypeCached;
-        public INamedTypeSymbol                            DoubleType            => DoubleTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     DecimalTypeCached;
-        public INamedTypeSymbol                            DecimalType           => DecimalTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     EnumTypeCached;
-        public INamedTypeSymbol                            EnumType              => EnumTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     DateTimeTypeCached;
-        public INamedTypeSymbol                            DateTimeType          => DateTimeTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     DateTimeOffsetTypeCached;
-        public INamedTypeSymbol                            DateTimeOffsetType    => DateTimeOffsetTypeCached.Value;
-
-        private Lazy<INamedTypeSymbol>                     GuidTypeCached;
-        public INamedTypeSymbol                            GuidType              => GuidTypeCached.Value;
-
         /// <summary>
         /// Initialize the state with no variable recorded yet.
         /// </summary>
@@ -92,25 +35,6 @@ namespace SecurityCodeScan.Analyzers.Taint
             Variables = new Dictionary<string, VariableState>();
             ObjectTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Object));
             StringTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_String));
-            CharTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Char));
-            BooleanTypeCached           = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Boolean));
-            ByteTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Byte));
-            SByteTypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_SByte));
-            Int16TypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int16));
-            UInt16TypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt16));
-            Int32TypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int32));
-            UInt32TypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt32));
-            Int64TypeCached             = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Int64));
-            UInt64TypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UInt64));
-            IntPtrTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_IntPtr));
-            UIntPtrTypeCached           = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_UIntPtr));
-            SingleTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Single));
-            DoubleTypeCached            = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Double));
-            DecimalTypeCached           = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Decimal));
-            EnumTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_Enum));
-            DateTimeTypeCached          = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetSpecialType(SpecialType.System_DateTime));
-            DateTimeOffsetTypeCached    = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.DateTimeOffset"));
-            GuidTypeCached              = new Lazy<INamedTypeSymbol>(() => ctx.Compilation.GetTypeByMetadataName("System.Guid"));
         }
 
         public ExecutionState(ExecutionState other)
@@ -119,25 +43,6 @@ namespace SecurityCodeScan.Analyzers.Taint
             Variables       = new Dictionary<string, VariableState>(other.VariableStates.Count);
             ObjectTypeCached            = other.ObjectTypeCached;
             StringTypeCached            = other.StringTypeCached;
-            CharTypeCached              = other.CharTypeCached;
-            BooleanTypeCached           = other.BooleanTypeCached;
-            ByteTypeCached              = other.ByteTypeCached;
-            SByteTypeCached             = other.SByteTypeCached;
-            Int16TypeCached             = other.Int16TypeCached;
-            UInt16TypeCached            = other.UInt16TypeCached;
-            Int32TypeCached             = other.Int32TypeCached;
-            UInt32TypeCached            = other.UInt32TypeCached;
-            Int64TypeCached             = other.Int64TypeCached;
-            UInt64TypeCached            = other.UInt64TypeCached;
-            IntPtrTypeCached            = other.IntPtrTypeCached;
-            UIntPtrTypeCached           = other.UIntPtrTypeCached;
-            SingleTypeCached            = other.SingleTypeCached;
-            DoubleTypeCached            = other.DoubleTypeCached;
-            DecimalTypeCached           = other.DecimalTypeCached;
-            EnumTypeCached              = other.EnumTypeCached;
-            DateTimeTypeCached          = other.DateTimeTypeCached;
-            DateTimeOffsetTypeCached    = other.DateTimeOffsetTypeCached;
-            GuidTypeCached              = other.GuidTypeCached;
 
             var otherVariableStateToNew = new Dictionary<VariableState, VariableState>();
             foreach (var otherVariablePair in other.VariableStates)
@@ -175,44 +80,6 @@ namespace SecurityCodeScan.Analyzers.Taint
                 ObjectTypeCached = state.ObjectTypeCached;
             if (!StringTypeCached.IsValueCreated && state.StringTypeCached.IsValueCreated)
                 StringTypeCached = state.StringTypeCached;
-            if (!CharTypeCached.IsValueCreated && state.CharTypeCached.IsValueCreated)
-                CharTypeCached = state.CharTypeCached;
-            if (!BooleanTypeCached.IsValueCreated && state.BooleanTypeCached.IsValueCreated)
-                BooleanTypeCached = state.BooleanTypeCached;
-            if (!ByteTypeCached.IsValueCreated && state.ByteTypeCached.IsValueCreated)
-                ByteTypeCached = state.ByteTypeCached;
-            if (!SByteTypeCached.IsValueCreated && state.SByteTypeCached.IsValueCreated)
-                SByteTypeCached = state.SByteTypeCached;
-            if (!Int16TypeCached.IsValueCreated && state.Int16TypeCached.IsValueCreated)
-                Int16TypeCached = state.Int16TypeCached;
-            if (!UInt16TypeCached.IsValueCreated && state.UInt16TypeCached.IsValueCreated)
-                UInt16TypeCached = state.UInt16TypeCached;
-            if (!Int32TypeCached.IsValueCreated && state.Int32TypeCached.IsValueCreated)
-                Int32TypeCached = state.Int32TypeCached;
-            if (!UInt32TypeCached.IsValueCreated && state.UInt32TypeCached.IsValueCreated)
-                UInt32TypeCached = state.UInt32TypeCached;
-            if (!Int64TypeCached.IsValueCreated && state.Int64TypeCached.IsValueCreated)
-                Int64TypeCached = state.Int64TypeCached;
-            if (!UInt64TypeCached.IsValueCreated && state.UInt64TypeCached.IsValueCreated)
-                UInt64TypeCached = state.UInt64TypeCached;
-            if (!IntPtrTypeCached.IsValueCreated && state.IntPtrTypeCached.IsValueCreated)
-                IntPtrTypeCached = state.IntPtrTypeCached;
-            if (!UIntPtrTypeCached.IsValueCreated && state.UIntPtrTypeCached.IsValueCreated)
-                UIntPtrTypeCached = state.UIntPtrTypeCached;
-            if (!SingleTypeCached.IsValueCreated && state.SingleTypeCached.IsValueCreated)
-                SingleTypeCached = state.SingleTypeCached;
-            if (!DoubleTypeCached.IsValueCreated && state.DoubleTypeCached.IsValueCreated)
-                DoubleTypeCached = state.DoubleTypeCached;
-            if (!DecimalTypeCached.IsValueCreated && state.DecimalTypeCached.IsValueCreated)
-                DecimalTypeCached = state.DecimalTypeCached;
-            if (!EnumTypeCached.IsValueCreated && state.EnumTypeCached.IsValueCreated)
-                EnumTypeCached = state.EnumTypeCached;
-            if (!DateTimeTypeCached.IsValueCreated && state.DateTimeTypeCached.IsValueCreated)
-                DateTimeTypeCached = state.DateTimeTypeCached;
-            if (!DateTimeOffsetTypeCached.IsValueCreated && state.DateTimeOffsetTypeCached.IsValueCreated)
-                DateTimeOffsetTypeCached = state.DateTimeOffsetTypeCached;
-            if (!GuidTypeCached.IsValueCreated && state.GuidTypeCached.IsValueCreated)
-                GuidTypeCached = state.GuidTypeCached;
         }
 
         public void Replace(ExecutionState other)


### PR DESCRIPTION
This addresses #152, where a false positive Open Redirect was given if either implicit string concatenation of safe types or string interpolation of safe types occurred. I'm in the process of migrating a rather old Web Forms site, and this package has been invaluable in identifying areas of concern.

The logic is straightforward and boils down to the following:
1. Check if the expression is being converted to a string.
2. If so, check if the expression is safe when converted to a string.
3. And if so, report that the expression is Safe.
4. Otherwise, propagate the original taint analysis.

I've not worked on a Roslyn analyzer before, ~~so I'm fairly certain I need to clean up the `IsSafeAsString` routine w.r.t. performance~~. I'm also unsure as to the null safety of `GetTypeInfo` and whether or not I should always be using `ConvertedType` or `Type`. I also did not add anything to the Visual Basic evaluation, as I do not do any development in VB and am unfamiliar with its language rules for implicit string conversion (but my understanding is things turn into numbers in situations where C# turns them into strings).