### PR TITLE
Add FileUpload.SaveAs to Path Traversal injection points

### DIFF
--- a/SecurityCodeScan/Config/Main.yml
+++ b/SecurityCodeScan/Config/Main.yml
@@ -2589,6 +2589,16 @@ Behavior:
     Field:
       Injectable: [SCS0018: AbsolutePath]
 
+ ## Web Forms
+
+  System.Web.UI.WebControls_FileUpload_SaveAs:
+    Namespace: System.Web.UI.WebControls
+    ClassName: FileUpload
+    Name: SaveAs
+    Method:
+      ArgTypes: (System.String)
+      InjectableArguments: [SCS0018: [0: AbsolutePath]]
+
  # LDAP injection
 
   DirectorySearcher_constructor_0:


### PR DESCRIPTION
While reviewing a Web Forms site we're migrating, I noticed that [`FileUpload.SaveAs`](https://docs.microsoft.com/en-us/dotnet/api/system.web.ui.webcontrols.fileupload.saveas?view=netframework-4.8) is not marked as a possible Path Traversal injection point ([SCS0018](https://github.com/security-code-scan/security-code-scan/blob/master/website/rules/0018.md)). Reviewing MSDN it notes that it throws an HttpException if the path is not rooted, but otherwise it does not state whether or not it protects against path injection.

Reviewing [ReferenceSource](https://referencesource.microsoft.com/#System.Web/HttpPostedFile.cs,678e7f8bc95c149f), it appears any checks performed are skin deep at best, and could be disabled by configuration:
```csharp
        public void SaveAs(String filename) {
            // VSWhidbey 82855
            if (!Path.IsPathRooted(filename)) {
                HttpRuntimeSection config = RuntimeConfig.GetConfig().HttpRuntime;
                if (config.RequireRootedSaveAsPath) {
                    throw new HttpException(SR.GetString(SR.SaveAs_requires_rooted_path, filename));
                }
            }
 
            FileStream f = new FileStream(filename, FileMode.Create);
            // ...
```
In testing it appears that `Path.IsPathRooted` alone cannot help against Path Injection:
```
> Path.IsPathRooted(@"C:\path\to\web\server\..\..\..\..\..\windows\system32")
true
```
Therefore, because this is just a forward to `FileStream`s ctor, I believe this should be annotated with the same injectable arguments.