### PR TITLE
Add basic support for lambda expressions in taint analysis

### DIFF
--- a/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -959,6 +959,95 @@ AuditMode: true
             await VerifyVisualBasicDiagnostic(visualBasicTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
         }
 
+        [TestCategory("Detect")]
+        [TestMethod]
+        public async Task LambdaSingleLine()
+        {
+            var cSharpTest = @"
+using System;
+using System.Data.SqlClient;
+
+namespace sample
+{
+    class Test
+    {
+        public void Run()
+        {
+            Func<string, SqlCommand> lambdaExpr = x => new SqlCommand(x);
+        }
+    }
+}
+";
+
+            var visualBasicTest = @"
+Imports System.Data.SqlClient
+
+Namespace sample
+    Class Test
+        Sub Run
+            Dim lambdaExpr = Function (x) New SqlCommand(x)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var testConfig = @"
+AuditMode: true
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(visualBasicTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+        }
+
+        [TestCategory("Detect")]
+        [TestMethod]
+        public async Task LambdaMultiline()
+        {
+            var cSharpTest = @"
+using System;
+using System.Data.SqlClient;
+
+namespace sample
+{
+    class Test
+    {
+        public void Run(string sql)
+        {
+            Func<string, SqlCommand> lambdaExpr = (x) => {
+                var cmd = new SqlCommand(x);
+                return cmd;
+            };
+        }
+    }
+}
+";
+
+            var visualBasicTest = @"
+Imports System.Data.SqlClient
+
+Namespace sample
+    Class Test
+        Sub Run
+            Dim lambdaExpr = Function (x)
+              Dim cmd As New SqlCommand(x)
+              Return cmd
+            End Function
+        End Sub
+    End Class
+End Namespace
+";
+
+            var testConfig = @"
+AuditMode: true
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+            await VerifyCSharpDiagnostic(cSharpTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+            await VerifyVisualBasicDiagnostic(visualBasicTest, Expected, optionsWithProjectConfig).ConfigureAwait(false);
+        }
+
+
         [TestCategory("Safe")]
         [TestMethod]
         public async Task VariableTransferSimple()

--- a/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
+++ b/SecurityCodeScan/Analyzers/Taint/CodeEvaluation/CSharpCodeEvaluation.cs
@@ -646,9 +646,16 @@ namespace SecurityCodeScan.Analyzers.Taint
                     }
 
                     return VisitAnonymousFunctionExpression(parenthesizedLambdaExpressionSyntax, state);
+                case SimpleLambdaExpressionSyntax simpleLambdaExpressionSyntax:
+                    if(ProjectConfiguration.AuditMode)
+                    {
+                        state.AddNewValue(ResolveIdentifier(simpleLambdaExpressionSyntax.Parameter.Identifier),
+                          new VariableState(simpleLambdaExpressionSyntax.Parameter, VariableTaint.Tainted));
+                    }
+
+                    return VisitAnonymousFunctionExpression(simpleLambdaExpressionSyntax, state);
                 case AnonymousFunctionExpressionSyntax anonymousFunctionExpressionSyntax:
                     return VisitAnonymousFunctionExpression(anonymousFunctionExpressionSyntax, state);
-
             }
 #if DEBUG
             if (Logger.IsConfigured())


### PR DESCRIPTION
This PR adds basic support for analyzing taints in lambda expressions. At the moment, the underlying expression kinds (e.g. `SimpleLambdaExpressionSyntax`, `ParenthesizedLambdaExpressionSyntax` etc.) are not really supported. Therefore taints in these are not correctly recognized, even if they don't depend on the parameters passed to the lambda.

The support here is only considered to be quite basic, as it surely lacks more in-depth analysis or support for things like #17. 