### PR TITLE
Add the Guid's constructor as a sanitizer

### DIFF
--- a/SecurityCodeScan/Config/Main.yml
+++ b/SecurityCodeScan/Config/Main.yml
@@ -703,6 +703,7 @@ Sanitizers:
 
   - Type: System.Guid
     Methods:
+      - Name: .ctor
       - Name: ToString
       - Name: Parse
       - Name: ParseExact


### PR DESCRIPTION
Either .Parse or new() result in the same cleansing. 

var x = Guid.Parse(Request["value"]) 
var x = new Guid(Request["value"])