### PR TITLE
Add .net 6 support to global security-scan core tool.

### DIFF
--- a/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
+++ b/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>security-scan</ToolCommandName>


### PR DESCRIPTION
Support both .NET 5 and .NET 6 for the security-scan global tool.
Directory.Build.props version is already bumped - 5.2.3
The latest security scan release is 5.2.2 (https://www.nuget.org/packages/security-scan/)

Resolves https://github.com/security-code-scan/security-code-scan/issues/231