### PR TITLE
Support VS 2019 and 2022

### DIFF
--- a/SecurityCodeScan.Vsix/source.extension.vsixmanifest
+++ b/SecurityCodeScan.Vsix/source.extension.vsixmanifest
@@ -13,9 +13,24 @@
         <Tags>SecurityCodeScan;Security.Code.Scan;Security Code Scan;Static Code Analysis;Security;Vulnerability;Analyzer;Analyzers;.NET;Roslyn;OWASP;Injection;XSS;CSRF;XXE;SQLi</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+		<InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro">
+			<ProductArchitecture>x86</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community">
+			<ProductArchitecture>x86</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise">
+			<ProductArchitecture>x86</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
It allows to install the VS extension to 2019 and 2022. 
Resolves: https://github.com/security-code-scan/security-code-scan/issues/227

Note: VSIX extension still has .VS2019 name.
 
![install1](https://user-images.githubusercontent.com/12700436/144900464-3adeb15f-7172-43ed-895b-e49b5fed1f21.png)

![install2](https://user-images.githubusercontent.com/12700436/144900465-6b4b13be-760c-4e96-aa25-5b0913d7d4b5.png)

![install3](https://user-images.githubusercontent.com/12700436/144900468-b76538e3-f51f-47a9-a10f-0e135007a227.png)

