### PR TITLE
Be able to exit with non-zero error code when warnings are found

### DIFF
--- a/SecurityCodeScan.Tool/Program.cs
+++ b/SecurityCodeScan.Tool/Program.cs
@@ -154,6 +154,7 @@ namespace SecurityCodeScan.Tool
         public bool ignoreMsBuildErrors = false;
         public bool showBanner = true;
         public bool cwe = false;
+        public bool failOnWarning = false;
         public HashSet<string> excludeWarnings = new HashSet<string>();
         public HashSet<string> includeWarnings = new HashSet<string>();
         public List<Glob> excludeProjects = new List<Glob>();
@@ -184,6 +185,7 @@ namespace SecurityCodeScan.Tool
                     { "n|no-banner",    "(Optional) don't show the banner", r => { showBanner = r == null; } },
                     { "v|verbose",      "(Optional) more diagnostic messages", r => { verbose = r != null; } },
                     { "ignore-msbuild-errors", "(Optional) Don't stop on MSBuild errors", r => { ignoreMsBuildErrors = r != null; } },
+                    { "f|fail-any-warn","(Optional) fail on any warnings with non-zero exit code", r => { failOnWarning = r != null; } },
                     { "h|?|help",       "show this message and exit", h => shouldShowHelp = h != null },
                 };
 
@@ -304,6 +306,13 @@ namespace SecurityCodeScan.Tool
                 var elapsed = DateTime.Now - startTime;
                 Console.WriteLine($@"Completed in {elapsed:hh\:mm\:ss}");
                 Console.WriteLine($@"{count} warnings");
+
+                if (parsedOptions.failOnWarning && count > 0)
+                {
+                    const int exitCode = 1;
+                    Console.WriteLine($@"Exiting with {exitCode} due to warnings.");
+                    return exitCode;
+                }
 
                 return 0;
             }


### PR DESCRIPTION
* add --fail-any-warn run option

This parameter lets the tool return a non-zero exit code which can then be detected by an Azure DevOps pipeline to flag/terminate the build.  A non-zero exit code is preferable to adding extra pipeline steps that check for existence of a .sarif file and parsing its contents.