### PR TITLE
Add .net 7 support to global security-scan core tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           3.1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
           3.1.x
           5.0.x
           6.0.x
+          7.0.x
         include-prerelease: false
 
     - name: Setup MSBuild.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 
@@ -42,7 +42,7 @@ jobs:
           8.0.x
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.1.3
+      uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Setup VSTest
       uses: darenm/Setup-VSTest@ee4202680b63bd7b2f0deb71ab55104b71917843

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,9 @@ jobs:
           5.0.x
           6.0.x
           7.0.x
-        include-prerelease: false
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Setup VSTest
       uses: darenm/Setup-VSTest@ee4202680b63bd7b2f0deb71ab55104b71917843

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           5.0.x
           6.0.x
           7.0.x
+          8.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1.3

--- a/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
+++ b/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>security-scan</ToolCommandName>

--- a/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
+++ b/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>security-scan</ToolCommandName>


### PR DESCRIPTION
Hi, 

I wanted to add .net 7 support to the global tool. 

I copied a previous [pr](https://github.com/security-code-scan/security-code-scan/pull/232) that added .net 6 support. 

However, am leaving this a draft PR as this does not compile on my mac even before I made my change. 

Maybe this will compile on a windows box with Visual Studio 2019/2022 installed on or more probably I would need to make some more changes elsewhere which I am happy to do with some guidance.

The relevant errors below:

<details><summary>Building the main project:</summary>

```text
/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Vsix/SecurityCodeScan.Vsix.csproj(92,11): error MSB4226: The imported project "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/xbuild/Microsoft/VisualStudio/v16.0/VSSDK/Microsoft.VsSDK.targets" was not found. Also, tried to find "VSSDK/Microsoft.VsSDK.targets" in the fallback search path(s) for $(VSToolsPath) - "/Library/Frameworks/Mono.framework/External/xbuild/Microsoft/VisualStudio/v16.0" . These search paths are defined in "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/MSBuild.dll.config". Confirm that the path in the <Import> declaration is correct, and that the file exists on disk in one of the search paths.
```
</details>


<details><summary>Building the `security-scan.csproj` project:</summary>

```text
▲ .NET Core [solrevdev/global-tool-support-dotnet-7] pwd
/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core
▲ .NET Core [solrevdev/global-tool-support-dotnet-7] dotnet build .
MSBuild version 17.4.0+18d5aef85 for .NET
  Determining projects to restore...
/usr/local/share/dotnet/sdk/7.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'net5.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
  All projects are up-to-date for restore.
/usr/local/share/dotnet/sdk/7.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'net5.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net6.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net6.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=netcoreapp3.1]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=netcoreapp3.1]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net7.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net7.0]

Build FAILED.

/usr/local/share/dotnet/sdk/7.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'net5.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/usr/local/share/dotnet/sdk/7.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'net5.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net6.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net6.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net5.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=netcoreapp3.1]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=netcoreapp3.1]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4801: The task factory "CodeTaskFactory" is not supported on the .NET Core version of MSBuild. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net7.0]
/Users/solrevdev/.nuget/packages/msbuild.assemblyversion/1.3.0/build/MSBuild.AssemblyVersion.targets(17,5): error MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly "/usr/local/share/dotnet/sdk/7.0.100/Microsoft.Build.Tasks.Core.dll". The task factory must return a value for the "TaskType" property. [/Users/solrevdev/Dropbox/Projects/github/security-code-scan/SecurityCodeScan.Tool/.NET Core/security-scan.csproj::TargetFramework=net7.0]
    2 Warning(s)
    8 Error(s)

Time Elapsed 00:00:01.80
```
</details>