### PR TITLE
Taint analysis vizualization (adding additional locations to TaintAnalyzer)

### DIFF
--- a/Roslyn/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/Roslyn/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             List<IOperation> list = new();
             foreach (var kvp in _operationStateMap)
             {
-                if (((kvp.Value as TaintedDataAbstractValue).Kind == TaintedDataAbstractValueKind.Tainted || kvp.Key.Kind == OperationKind.Invocation) && (kvp.Value as TaintedDataAbstractValue).SourceOrigins.Contains(sourceOrigin))
+                if ((kvp.Value as TaintedDataAbstractValue).Kind == TaintedDataAbstractValueKind.Tainted && (kvp.Value as TaintedDataAbstractValue).SourceOrigins.Contains(sourceOrigin))
                 {
                     list.Add(kvp.Key);
                 }

--- a/Roslyn/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/Roslyn/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
@@ -142,9 +143,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
         }
 
-        internal bool InterproceduralResultAvailable()
+        internal int InterproceduralResultCount()
         {
-            return _interproceduralResultsMap.Count > 0;
+            return _interproceduralResultsMap.Count;
         }
 
         internal List<IOperation> GetTaintedOperations(SymbolAccess sourceOrigin)
@@ -162,6 +163,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return list;
         }
 
+        internal DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue>? GetInterproceduralResultByIndex(int index)
+        {
+            var element = _interproceduralResultsMap.ElementAt(index);
+
+            return (DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue>)element.Value;
+        }
 
         internal DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue>? TryGetInterproceduralResult(IOperation operation)
         {

--- a/Roslyn/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/Roslyn/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -140,6 +141,27 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 return value;
             }
         }
+
+        internal bool InterproceduralResultAvailable()
+        {
+            return _interproceduralResultsMap.Count > 0;
+        }
+
+        internal List<IOperation> GetTaintedOperations(SymbolAccess sourceOrigin)
+        {
+
+            List<IOperation> list = new();
+            foreach (var kvp in _operationStateMap)
+            {
+                if (((kvp.Value as TaintedDataAbstractValue).Kind == TaintedDataAbstractValueKind.Tainted || kvp.Key.Kind == OperationKind.Invocation) && (kvp.Value as TaintedDataAbstractValue).SourceOrigins.Contains(sourceOrigin))
+                {
+                    list.Add(kvp.Key);
+                }
+            }
+
+            return list;
+        }
+
 
         internal DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue>? TryGetInterproceduralResult(IOperation operation)
         {

--- a/SecurityCodeScan.Test/Helpers/DiagnosticResult.cs
+++ b/SecurityCodeScan.Test/Helpers/DiagnosticResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace SecurityCodeScan.Test.Helpers
@@ -76,5 +77,30 @@ namespace SecurityCodeScan.Test.Helpers
             result.LocationsField.Add(new DiagnosticResultLocation(path, line, column));
             return result;
         }
+
+        public DiagnosticResult WithAdditionalLocations(List<ResultLocation> resultLocations)
+        {
+            DiagnosticResult result = this;
+            var path = $"{DiagnosticVerifier.DefaultFilePathPrefix}0";
+            if (result.LocationsField == null)
+                result.LocationsField = new List<DiagnosticResultLocation>();
+
+            result.LocationsField.AddRange(resultLocations.Select(l => new DiagnosticResultLocation(path, l.Line, l.Column)));
+            
+            return result;
+        }
+
+    }
+
+    public struct ResultLocation
+    {
+        public ResultLocation(int line, int column)
+        {
+            Line = line;
+            Column = column;
+        }
+
+        public int Line { get; }
+        public int Column { get; }
     }
 }

--- a/SecurityCodeScan.Test/Helpers/DiagnosticResult.cs
+++ b/SecurityCodeScan.Test/Helpers/DiagnosticResult.cs
@@ -10,6 +10,13 @@ namespace SecurityCodeScan.Test.Helpers
     /// </summary>
     public struct DiagnosticResultLocation
     {
+        public DiagnosticResultLocation()
+        {
+            Line = -1;
+            Column = -1;
+            Path = $"{DiagnosticVerifier.DefaultFilePathPrefix}0";
+        }
+
         public DiagnosticResultLocation(string path, int line, int column)
         {
             if (line < -1)
@@ -37,9 +44,15 @@ namespace SecurityCodeScan.Test.Helpers
     /// </summary>
     public struct DiagnosticResult
     {
-        private List<DiagnosticResultLocation> LocationsField;
+        public DiagnosticResult()
+        {
+        }
 
-        public IReadOnlyList<DiagnosticResultLocation> Locations => LocationsField;
+        public DiagnosticResultLocation Location { get; private set; } = new DiagnosticResultLocation();
+
+        private List<DiagnosticResultLocation> AdditionalLocationsField;
+
+        public IReadOnlyList<DiagnosticResultLocation> AdditionalLocations => AdditionalLocationsField;
 
         public DiagnosticSeverity? Severity { get; set; }
 
@@ -47,9 +60,9 @@ namespace SecurityCodeScan.Test.Helpers
 
         public string Message { get; set; }
 
-        public int Line => LocationsField != null ? Locations[0].Line : -1;
+        public int Line => Location.Line;
 
-        public int Column => LocationsField != null ? Locations[0].Column : -1;
+        public int Column => Location.Column;
 
         public DiagnosticResult WithMessage(string message)
         {
@@ -71,30 +84,28 @@ namespace SecurityCodeScan.Test.Helpers
         private DiagnosticResult WithLocation(string path, int line, int column)
         {
             DiagnosticResult result = this;
-            if (result.LocationsField == null)
-                result.LocationsField = new List<DiagnosticResultLocation>(1);
+            result.Location = new DiagnosticResultLocation(path, line, column);
 
-            result.LocationsField.Add(new DiagnosticResultLocation(path, line, column));
             return result;
         }
 
-        public DiagnosticResult WithAdditionalLocations(List<ResultLocation> resultLocations)
+        public DiagnosticResult WithAdditionalLocations(List<ResultAdditionalLocation> resultLocations)
         {
             DiagnosticResult result = this;
             var path = $"{DiagnosticVerifier.DefaultFilePathPrefix}0";
-            if (result.LocationsField == null)
-                result.LocationsField = new List<DiagnosticResultLocation>();
+            if (result.AdditionalLocationsField == null)
+                result.AdditionalLocationsField = new List<DiagnosticResultLocation>();
 
-            result.LocationsField.AddRange(resultLocations.Select(l => new DiagnosticResultLocation(path, l.Line, l.Column)));
+            result.AdditionalLocationsField.AddRange(resultLocations.Select(l => new DiagnosticResultLocation(path, l.Line, l.Column)));
             
             return result;
         }
 
     }
 
-    public struct ResultLocation
+    public struct ResultAdditionalLocation
     {
-        public ResultLocation(int line, int column)
+        public ResultAdditionalLocation(int line, int column)
         {
             Line = line;
             Column = column;

--- a/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
+++ b/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
@@ -634,6 +634,7 @@
     <Compile Include="Tests\Taint\EntryPointsTaintAnalyzerTest.cs" />
     <Compile Include="Tests\Taint\OpenRedirectAnalyzerTest.cs" />
     <Compile Include="Tests\Taint\LdapInjectionAnalyzerTest.cs" />
+    <Compile Include="Tests\Taint\TaintFlowVisualizationTests.cs" />
     <Compile Include="Tests\Taint\SqlInjectionAnalyzerTest.cs" />
     <Compile Include="Tests\Taint\TaintAnalyzerSanitizerTest.cs" />
     <Compile Include="Tests\Taint\TaintTransferTest.cs" />

--- a/SecurityCodeScan.Test/Tests/Taint/TaintFlowVisualizationTests.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintFlowVisualizationTests.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SecurityCodeScan.Analyzers.Taint;
+using SecurityCodeScan.Test.Config;
+using SecurityCodeScan.Test.Helpers;
+
+namespace SecurityCodeScan.Test.Taint
+{
+    [TestClass]
+    public class TaintFlowVisualizationTests : DiagnosticVerifier
+    {
+        protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers(string _)
+        {
+            return new[] { new SqlInjectionTaintAnalyzer() };
+        }
+
+        private static readonly PortableExecutableReference[] References =
+        {            
+            MetadataReference.CreateFromFile(typeof(System.Web.UI.WebControls.SqlDataSource).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Data.Entity.DbContext).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.Practices.EnterpriseLibrary.Data.Sql.SqlDatabase).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.EntityFrameworkCore.DbContext).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.EntityFrameworkCore.RelationalQueryableExtensions).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Data.SQLite.SQLiteCommand).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.Data.Sqlite.SqliteCommand).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Web.Mvc.Controller).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(NHibernate.ISession).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Cassandra.ISession).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Npgsql.NpgsqlCommand).Assembly.Location),
+            MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")
+                                                     .Location),
+            MetadataReference.CreateFromFile(Assembly.Load("Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")
+                                                     .Location),
+        };
+
+
+        protected override IEnumerable<MetadataReference> GetAdditionalReferences() => References;
+
+        [TestMethod]
+        public async Task TaintedVizSimpleTest()
+        {
+            var cSharpTest = $@"
+#pragma warning disable 8019
+    using System;
+    using System.Data.SqlClient;
+    using System.Data.Common;
+    using System.Data;
+    using System.Web.UI.WebControls;
+    using System.Data.Entity;
+    using System.Threading;
+    using Microsoft.Practices.EnterpriseLibrary.Data.Sql;
+    using System.Data.SQLite;
+    using System.Web.Mvc;
+#pragma warning restore 8019
+
+namespace sample
+{{
+    public class MyFooController : Controller
+    {{
+        public void Run(string input, params object[] parameters)
+        {{
+            DoStuff(input);
+        }}
+
+        private void DoStuff(string stuffInput)
+        {{
+            new SQLiteCommand(stuffInput);
+        }}
+    }}
+}}
+";
+            var expected = new DiagnosticResult
+            {
+                Id = "SCS0002",
+                Severity = DiagnosticSeverity.Warning,
+            };
+            await VerifyCSharpDiagnostic(cSharpTest, expected).ConfigureAwait(false);
+
+        }
+
+        [TestMethod]
+        public async Task TaintedVizOpsNotLeadingToSinkTest()
+        {
+            var cSharpTest = $@"
+#pragma warning disable 8019
+    using System;
+    using System.Data.SqlClient;
+    using System.Data.Common;
+    using System.Data;
+    using System.Web.UI.WebControls;
+    using System.Data.Entity;
+    using System.Threading;
+    using Microsoft.Practices.EnterpriseLibrary.Data.Sql;
+    using System.Data.SQLite;
+    using System.Web.Mvc;
+#pragma warning restore 8019
+
+namespace sample
+{{
+    public class MyFooController : Controller
+    {{
+        public void Run(string input)
+        {{
+            var doNotStuff = input + ""tainted"";
+            DoNotStuff(doNotStuff);
+            DoStuff(input);
+        }}
+
+        private void DoStuff(string stuffInput)
+        {{
+            new SQLiteCommand(stuffInput);
+        }}
+
+        private void DoNotStuff(string stuffNotInput)
+        {{
+            return;
+        }}
+
+
+    }}
+}}
+";
+            var expected = new DiagnosticResult
+            {
+                Id = "SCS0002",
+                Severity = DiagnosticSeverity.Warning,
+            };
+            await VerifyCSharpDiagnostic(cSharpTest, expected).ConfigureAwait(false);
+
+        }
+
+
+        [DataRow("var sql = new NpgsqlCommand(\"SELECT * FROM users WHERE username = '\" + username + \"';\");",                  true)]
+        [DataTestMethod]
+        public async Task NpgsqlInjection(string sink, bool warn)
+        {
+            var testConfig = @"
+TaintEntryPoints:
+  sample.MyFoo:
+    Method:
+      Name: Execute
+";
+
+            var optionsWithProjectConfig = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
+
+            var cSharpTest = $@"
+using Npgsql;
+
+namespace sample
+{{
+    public class MyFoo
+    {{
+        public void Execute(string username)
+        {{
+            {sink}
+        }}
+    }}
+}}
+";
+
+            sink = sink.Replace("var ", "Dim ");
+            sink = sink.Replace(";", "\r\n");
+            sink = sink.Replace("null", "Nothing");
+
+            var visualBasicTest = $@"
+Imports Npgsql
+
+Namespace sample
+    Public Class MyFoo
+        Public Sub Execute(ByVal username As String)
+            {sink}
+        End Sub
+    End Class
+End Namespace
+";
+            var expected = new DiagnosticResult
+            {
+                Id       = "SCS0002",
+                Severity = DiagnosticSeverity.Warning,
+            };
+
+            if (warn)
+            {
+                await VerifyCSharpDiagnostic(cSharpTest, expected, optionsWithProjectConfig).ConfigureAwait(false);
+                await VerifyVisualBasicDiagnostic(visualBasicTest, expected, optionsWithProjectConfig).ConfigureAwait(false);
+            }
+            else
+            {
+                await VerifyCSharpDiagnostic(cSharpTest, options: optionsWithProjectConfig).ConfigureAwait(false);
+                await VerifyVisualBasicDiagnostic(visualBasicTest, options: optionsWithProjectConfig).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/SecurityCodeScan.Test/Tests/Taint/TaintFlowVisualizationTests.cs
+++ b/SecurityCodeScan.Test/Tests/Taint/TaintFlowVisualizationTests.cs
@@ -144,7 +144,7 @@ End Namespace
                 };
 
             var config = ConfigurationTest.CreateAnalyzersOptionsWithConfig(testConfig);
-            //await VerifyCSharpDiagnostic(cSharpTest, expectedCSharp, options: config).ConfigureAwait(false);
+            await VerifyCSharpDiagnostic(cSharpTest, expectedCSharp, options: config).ConfigureAwait(false);
             await VerifyVisualBasicDiagnostic(visualBasicTest, expectedVB, options: config).ConfigureAwait(false);
         }
 

--- a/SecurityCodeScan.Test/Verifiers/DiagnosticVerifier.cs
+++ b/SecurityCodeScan.Test/Verifiers/DiagnosticVerifier.cs
@@ -253,7 +253,7 @@ Diagnostics:
                 {
                     VerifyDiagnosticLocation(documentsWithLineNumbers,
                                              actual.Location,
-                                             expected.Locations.First(),
+                                             expected.Location,
                                              language,
                                              diagnosticsOutput);
                 }

--- a/SecurityCodeScan/Analyzers/Taint/TaintAnalyzer.cs
+++ b/SecurityCodeScan/Analyzers/Taint/TaintAnalyzer.cs
@@ -558,15 +558,10 @@ namespace SecurityCodeScan.Analyzers.Taint
                                                                 }
 
                                                                 var messageArgs = new object[4];
-                                                                messageArgs[0] = sourceSink.Sink.Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                                                                messageArgs[0] = sourceSink.Sink.Symbol.Name; // sourceSink.Sink.Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                                                                 messageArgs[1] = sourceSink.Sink.AccessingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                                                                 messageArgs[2] = sourceOrigin.Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                                                                 messageArgs[3] = sourceOrigin.AccessingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-
-                                                                // sourceSink.Sink.Symbol.Name,
-                                                                // sourceSink.Sink.AccessingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                                                                // sourceOrigin.Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                                                                // sourceOrigin.AccessingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
 
                                                                 Diagnostic diagnostic = Diagnostic.Create(
                                                                     TaintedDataEnteringSinkDescriptor,

--- a/SecurityCodeScan/Config/Configuration.cs
+++ b/SecurityCodeScan/Config/Configuration.cs
@@ -697,6 +697,7 @@ namespace SecurityCodeScan.Config
             PasswordValidatorRequiredLength    = configData.PasswordValidatorRequiredLength    ?? 0;
             MaxInterproceduralMethodCallChain  = configData.MaxInterproceduralMethodCallChain ?? 3;
             MaxInterproceduralLambdaOrLocalFunctionCallChain = configData.MaxInterproceduralLambdaOrLocalFunctionCallChain ?? 3;
+            TaintFlowVisualizationEnabled = configData.TaintFlowVisualizationEnabled ?? false;
 
             if (configData.PasswordValidatorRequiredProperties != null)
             {
@@ -803,6 +804,7 @@ namespace SecurityCodeScan.Config
         public uint MaxInterproceduralLambdaOrLocalFunctionCallChain { get; private set; }
         public int  PasswordValidatorRequiredLength    { get; private set; }
         public int  MinimumPasswordValidatorProperties { get; private set; }
+        public bool TaintFlowVisualizationEnabled { get; private set; }
 
         private readonly HashSet<string>         _PasswordValidatorRequiredProperties;
         public           ReadOnlyHashSet<string> PasswordValidatorRequiredProperties { get; }

--- a/SecurityCodeScan/Config/ConfigurationManager.cs
+++ b/SecurityCodeScan/Config/ConfigurationManager.cs
@@ -313,6 +313,8 @@ namespace SecurityCodeScan.Config
         public Dictionary<string, AttributeCheck>      CsrfCheck                           { get; set; }
         public Dictionary<string, AttributeCheck>      AuthorizeCheck                      { get; set; }
         public string                                  WebConfigFiles                      { get; set; }
+        public bool?                                   TaintFlowVisualizationEnabled       { get; set; }
+        
     }
 
     internal class Transfer

--- a/SecurityCodeScan/Config/ConfigurationManager.cs
+++ b/SecurityCodeScan/Config/ConfigurationManager.cs
@@ -172,6 +172,9 @@ namespace SecurityCodeScan.Config
             if (config2.AuditMode.HasValue)
                 config1.AuditMode = config2.AuditMode.Value;
 
+            if (config2.TaintFlowVisualizationEnabled.HasValue)
+                config1.TaintFlowVisualizationEnabled = config2.TaintFlowVisualizationEnabled.Value;
+
             if (config2.MinimumPasswordValidatorProperties.HasValue)
                 config1.MinimumPasswordValidatorProperties = config2.MinimumPasswordValidatorProperties.Value;
 

--- a/SecurityCodeScan/Config/Main.yml
+++ b/SecurityCodeScan/Config/Main.yml
@@ -10,6 +10,9 @@ MaxInterproceduralMethodCallChain: 3
 
 MaxInterproceduralLambdaOrLocalFunctionCallChain: 3
 
+# Generate a list of additional locations for the taint analyzer
+TaintFlowVisualizationEnabled: true
+
 # Case insensitive pattern of web config files to analyze when AdditionalFileItemNames are configured (see https://security-code-scan.github.io/#Analyzing.aspxandweb.configFiles)
 WebConfigFiles: ^web\.config.*
 

--- a/SecurityCodeScan/Config/Main.yml
+++ b/SecurityCodeScan/Config/Main.yml
@@ -10,8 +10,8 @@ MaxInterproceduralMethodCallChain: 3
 
 MaxInterproceduralLambdaOrLocalFunctionCallChain: 3
 
-# Generate a list of additional locations for the taint analyzer
-TaintFlowVisualizationEnabled: true
+# Generate a list of additional locations for the taint analyzer (experimental feature: disabled by default)
+TaintFlowVisualizationEnabled: false
 
 # Case insensitive pattern of web config files to analyze when AdditionalFileItemNames are configured (see https://security-code-scan.github.io/#Analyzing.aspxandweb.configFiles)
 WebConfigFiles: ^web\.config.*


### PR DESCRIPTION
It is a new experimental feature that can be extremely helpful while reviewing any vulnerability found with taint analysis (aka all injections and not a single line item).

![image](https://user-images.githubusercontent.com/12700436/206740715-d060807e-07d7-44ae-895c-d31051ec9c6e.png)

![image](https://user-images.githubusercontent.com/12700436/206740839-a8601e19-2533-4df6-8e8f-1e101354bab4.png)

**End goal**: To be able to properly populate the SARIF file with all additional locations to visualize the code flow.

**How**:
A new flag `TaintFlowVisualizationEnabled` was introduced. It is `disabled by default` and works only with AuditMode=off.

Implementation is a bit hacky; instead of modifying a taint flow analysis logic (Roslyn stuff), I do additional post-processing to recreate the data flow. This way, I won't decrease performance significantly, and analyzers still produce the same results.
Due to internal limitations, the solution may not be ideal in its current state. 

**If it is something that you find interesting, please review the PR and provide feedback. I tried not to change too much**

Example of code flow - Code Scanning with Github - I want to produce something similar at the end; this one is the first step:
![code flow](https://res.cloudinary.com/practicaldev/image/fetch/s---8_GA2PK--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://dev-to-uploads.s3.amazonaws.com/uploads/articles/zjrssv22cvwcarke3lfr.png)
