### PR TITLE
Upgrade .NET Core to .NET 8 LTS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <AssemblyVersionNumber>5.6.8.0</AssemblyVersionNumber>
+        <AssemblyVersionNumber>5.6.8.1</AssemblyVersionNumber>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <AssemblyVersionNumber>5.6.7.9</AssemblyVersionNumber>
+        <AssemblyVersionNumber>5.6.8.0</AssemblyVersionNumber>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
+++ b/SecurityCodeScan.Test/SecurityCodeScan.Test.csproj
@@ -344,9 +344,6 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.1.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.0.82\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>

--- a/SecurityCodeScan.Test/packages.config
+++ b/SecurityCodeScan.Test/packages.config
@@ -103,7 +103,6 @@
   <package id="Microsoft.VisualBasic" version="10.0.1" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Composition" version="16.1.8" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Composition.NetFxAttributes" version="16.1.8" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.2" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />

--- a/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
+++ b/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
@@ -36,17 +36,17 @@
     <Compile Include="..\SarifV2ErrorLogger.cs" Link="SarifV2ErrorLogger.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.Glob" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.11.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="DotNet.Glob" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
+++ b/SecurityCodeScan.Tool/.NET Core/security-scan.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>security-scan</ToolCommandName>
@@ -24,11 +23,9 @@
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
-
   <PropertyGroup>
     <NoWarn>1701;1702;8601</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\ErrorLogger.cs" Link="ErrorLogger.cs" />
     <Compile Include="..\Hash.cs" Link="Hash.cs" />
@@ -38,7 +35,6 @@
     <Compile Include="..\SarifErrorLogger.cs" Link="SarifErrorLogger.cs" />
     <Compile Include="..\SarifV2ErrorLogger.cs" Link="SarifV2ErrorLogger.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="3.1.2" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
@@ -55,18 +51,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\SecurityCodeScan\SecurityCodeScan.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\SecurityCodeScan.Vsix\icon.png">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath>
+      </PackagePath>
     </None>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- Used the Visual Studio upgrade assistant to bump the security-scan project to target .NET 8
- Upgraded nuget packages
- Removed Microsoft.VisualStudio.Validation that was causing build errors. Specifically I thing something is wrong with the path that causes an issue in Windows or in Nuget / Visual Studio. Removing this didn't seem to cause any tests to fail.

Tests pass:
![image](https://github.com/user-attachments/assets/16b037e4-7879-4145-9e5a-568a69ca1c3e)
